### PR TITLE
Fix some spelling errors.

### DIFF
--- a/examples/filetree/filetree.go
+++ b/examples/filetree/filetree.go
@@ -40,7 +40,7 @@ func (fb *FileBrowse) UpdateFiles() {
 	fb.Files.OpenPath(string(fb.ProjRoot))
 }
 
-// IsEmpty returns true if given FileBrowse project is empty -- has not been set to a valide path
+// IsEmpty returns true if given FileBrowse project is empty -- has not been set to a valid path
 func (fb *FileBrowse) IsEmpty() bool {
 	return fb.ProjRoot == ""
 }

--- a/examples/marbles/graph.go
+++ b/examples/marbles/graph.go
@@ -147,7 +147,7 @@ func (gr *Graph) Reset() {
 // Line represents one line with an equation etc
 type Line struct {
 	Eq     string                         `width:"60" desc:"equation: use 'x' for the x value, and must use * for multiplication, and start with 0 for decimal numbers (0.01 instead of .01)"`
-	MinX   float32                        `step:"1" desc:"Mininum x value for this line."`
+	MinX   float32                        `step:"1" desc:"Minimum x value for this line."`
 	MaxX   float32                        `step:"1" desc:"Maximum x value for this line."`
 	Color  string                         `desc:"color to draw the line in"`
 	Bounce float32                        `min:"0" max:"2" step:".05" desc:"how bouncy the line is -- 1 = perfectly bouncy, 0 = no bounce at all"`
@@ -340,7 +340,7 @@ type Params struct {
 	NSteps     int     `min:"100" max:"10000" step:"10" desc:"number of steps to take when running"`
 	StartSpeed float32 `min:"0" max:"2" step:".05" desc:"Coordinates per unit of time"`
 	UpdtRate   float32 `min:"0.001" max:"1" step:".01" desc:"how fast to move along velocity vector -- lower = smoother, more slow-mo"`
-	Gravity    float32 `min:"0" max:"2" step:".01" desc:"how fast it accellerates down"`
+	Gravity    float32 `min:"0" max:"2" step:".01" desc:"how fast it accelerates down"`
 }
 
 func (pr *Params) Defaults() {

--- a/examples/widgets/widgets.go
+++ b/examples/widgets/widgets.go
@@ -151,7 +151,7 @@ See <a href="https://github.com/goki/gi/blob/master/examples/widgets/README.md">
 	checkbox := brow.AddNewChild(gi.KiT_CheckBox, "checkbox").(*gi.CheckBox)
 	checkbox.Text = "Toggle"
 
-	// note: receiver for menut items with shortcuts must be a Node2D or Window
+	// note: receiver for menu items with shortcuts must be a Node2D or Window
 	mb1 := brow.AddNewChild(gi.KiT_MenuButton, "menubutton1").(*gi.MenuButton)
 	mb1.SetText("Menu Button")
 	mb1.Menu.AddAction(gi.ActOpts{Label: "Menu Item 1", Shortcut: "Shift+Control+1", Data: 1},

--- a/gi/bitmap.go
+++ b/gi/bitmap.go
@@ -174,7 +174,7 @@ func SavePNG(path string, im image.Image) error {
 
 // ImageClearer makes an image more transparent -- pct is amount to alter
 // alpha transparency factor by -- 100 = fully transparent, 0 = no change --
-// affects the image itself -- make a copy of you want to keept the original
+// affects the image itself -- make a copy if you want to keep the original
 // or see bild/blend/multiply -- this is specifically used for gi DND etc
 func ImageClearer(im *image.RGBA, pct float32) {
 	pct = InRange32(pct, 0, 100.0)

--- a/gi/buttons.go
+++ b/gi/buttons.go
@@ -66,7 +66,7 @@ const (
 	// Pressed means button pushed down but not yet up
 	ButtonPressed
 
-	// Released means mose button was released - typically look at
+	// Released means mouse button was released - typically look at
 	// ButtonClicked instead of this one
 	ButtonReleased
 
@@ -496,7 +496,7 @@ type ButtonWidget interface {
 	// actually differ in functionality.
 	ButtonRelease()
 
-	// StyleParts is called during Style2D to handle stying associated with
+	// StyleParts is called during Style2D to handle styling associated with
 	// parts -- icons mainly.
 	StyleParts()
 

--- a/gi/color.go
+++ b/gi/color.go
@@ -490,7 +490,7 @@ func ColorFromString(str string, base color.Color) (Color, error) {
 	return c, err
 }
 
-// parse Hex color -- this is from fogelman/gg I think..
+// parse Hex color -- this is from fogleman/gg I think..
 func (c *Color) ParseHex(x string) error {
 	x = strings.TrimPrefix(x, "#")
 	var r, g, b, a int

--- a/gi/colorparse.go
+++ b/gi/colorparse.go
@@ -319,7 +319,7 @@ func (cs *ColorSpec) UnmarshalXML(decoder *xml.Decoder, se xml.StartElement) err
 			if err == io.EOF {
 				break
 			}
-			log.Printf("gi.ColorSpec.UmarshalXML color parsing error: %v\n", err)
+			log.Printf("gi.ColorSpec.UnmarshalXML color parsing error: %v\n", err)
 			return err
 		}
 		switch se := t.(type) {
@@ -433,7 +433,7 @@ func (cs *ColorSpec) UnmarshalXML(decoder *xml.Decoder, se xml.StartElement) err
 					cs.Gradient.Stops = append(cs.Gradient.Stops, stop)
 				}
 			default:
-				errStr := "gi.GolorSpec Cannot process svg element " + se.Name.Local
+				errStr := "gi.ColorSpec Cannot process svg element " + se.Name.Local
 				log.Println(errStr)
 			}
 		case xml.EndElement:

--- a/gi/dialogs.go
+++ b/gi/dialogs.go
@@ -384,7 +384,7 @@ func (dlg *Dialog) StdButtonConfig(stretch, ok, cancel bool) kit.TypeAndNameList
 	return config
 }
 
-// StdButtonConnnect connects standard buttons in given button box layout to
+// StdButtonConnect connects standard buttons in given button box layout to
 // Accept / Cancel actions
 func (dlg *Dialog) StdButtonConnect(ok, cancel bool, bb *Layout) {
 	if ok {

--- a/gi/doc.go
+++ b/gi/doc.go
@@ -13,7 +13,7 @@ The 2D scenegraph supports:
 	* Widget nodes for GUI actions (Buttons, Menus etc) -- render directly via Paint
 	* Layouts for placing widgets, which are also container nodes
 	* CSS-based styling, directly on Node Props (properties), and CSS StyleSheet
-	* svg sub-package with SVG Viewport and shapes, paths, etc -- full SVG suport
+	* svg sub-package with SVG Viewport and shapes, paths, etc -- full SVG support
 	* Icon is a wrapper around an SVG -- any SVG icon can be used
 
 Layout Logic
@@ -52,7 +52,7 @@ Controlling the layout involves the following style properties:
       any available space.  The preferred size of the item is used to
       determine how much of the space is used by each stretchable element, so
       you can set that to achieve different proportional spacing.  By default
-      the Stretch is just the minumum 1em in preferred size.
+      the Stretch is just the minimum 1em in preferred size.
 
 	* align-horiz / align-vert: for the other dimension in a Layout (e.g., for
       LayoutHoriz, the vertical dimension) this specifies how the items are
@@ -87,7 +87,7 @@ other Go package.  Furthermore, the ValueView framework allows for easy
 customization and extension of the GUI representation, based on the classic Go
 "Stringer"-like interface paradigm -- simply define a ValueView() method on
 any type, returning giv.ValueView that manages the interface between data
-structures and GUI represnetations.
+structures and GUI representations.
 
 See giv sub-package for all the View elements
 

--- a/gi/font.go
+++ b/gi/font.go
@@ -46,7 +46,7 @@ import (
 // font library.  see text.go for rendering code
 
 // FontName is used to specify an font -- just the unique name of the font
-// family -- automtically provides a chooser menu for fonts using ValueView
+// family -- automatically provides a chooser menu for fonts using ValueView
 // system
 type FontName string
 
@@ -675,7 +675,7 @@ func (ev *FontVariants) UnmarshalJSON(b []byte) error { return kit.EnumUnmarshal
 //////////////////////////////////////////////////////////////////////////////////
 // Font library
 
-// loadFontMu protects the font loading calls, which are not concurent-safe
+// loadFontMu protects the font loading calls, which are not concurrent-safe
 var loadFontMu sync.Mutex
 
 // FontInfo contains basic font information for choosing a given font --

--- a/gi/geom2d.go
+++ b/gi/geom2d.go
@@ -885,7 +885,7 @@ func (gm *Geom2DInt) SetRect(r image.Rectangle) {
 }
 
 ///////////////////////////////////////////////////////////
-// utlities
+// utilities
 
 func Radians(degrees float32) float32 {
 	return degrees * math32.Pi / 180

--- a/gi/icon.go
+++ b/gi/icon.go
@@ -13,7 +13,7 @@ import (
 )
 
 // IconName is used to specify an icon -- currently just the unique name of
-// the icon -- automtically provides a chooser menu for icons using ValueView
+// the icon -- automatically provides a chooser menu for icons using ValueView
 // system
 type IconName string
 

--- a/gi/keyfun.go
+++ b/gi/keyfun.go
@@ -252,7 +252,7 @@ func (km *KeyMap) Update(kmName KeyMapName) {
 // the local widget's key event processing, with the shortcut only operating
 // when no conflicting widgets are in focus.  Shortcuts are always window-wide
 // and are intended for global window / toolbar actions.  Widget-specific key
-// functions should be be handeled directly within widget key event
+// functions should be handled directly within widget key event
 // processing.
 type Shortcuts map[key.Chord]*Action
 

--- a/gi/layout.go
+++ b/gi/layout.go
@@ -45,14 +45,14 @@ type LayoutStyle struct {
 	ZIndex         int         `xml:"z-index" desc:"prop: z-index = ordering factor for rendering depth -- lower numbers rendered first -- sort children according to this factor"`
 	AlignH         Align       `xml:"horizontal-align" desc:"prop: horizontal-align = horizontal alignment -- for widget layouts -- not a standard css property"`
 	AlignV         Align       `xml:"vertical-align" desc:"prop: vertical-align = vertical alignment -- for widget layouts -- not a standard css property"`
-	PosX           units.Value `xml:"x" desc:"prop: x = horizontal position -- often superceded by layout but otherwise used"`
-	PosY           units.Value `xml:"y" desc:"prop: y = vertical position -- often superceded by layout but otherwise used"`
+	PosX           units.Value `xml:"x" desc:"prop: x = horizontal position -- often superseded by layout but otherwise used"`
+	PosY           units.Value `xml:"y" desc:"prop: y = vertical position -- often superseded by layout but otherwise used"`
 	Width          units.Value `xml:"width" desc:"prop: width = specified size of element -- 0 if not specified"`
 	Height         units.Value `xml:"height" desc:"prop: height = specified size of element -- 0 if not specified"`
 	MaxWidth       units.Value `xml:"max-width" desc:"prop: max-width = specified maximum size of element -- 0  means just use other values, negative means stretch"`
 	MaxHeight      units.Value `xml:"max-height" desc:"prop: max-height = specified maximum size of element -- 0 means just use other values, negative means stretch"`
-	MinWidth       units.Value `xml:"min-width" desc:"prop: min-width = specified mimimum size of element -- 0 if not specified"`
-	MinHeight      units.Value `xml:"min-height" desc:"prop: min-height = specified mimimum size of element -- 0 if not specified"`
+	MinWidth       units.Value `xml:"min-width" desc:"prop: min-width = specified minimum size of element -- 0 if not specified"`
+	MinHeight      units.Value `xml:"min-height" desc:"prop: min-height = specified minimum size of element -- 0 if not specified"`
 	Margin         units.Value `xml:"margin" desc:"prop: margin = outer-most transparent space around box element -- todo: can be specified per side"`
 	Padding        units.Value `xml:"padding" desc:"prop: padding = transparent space around central content of box -- todo: if 4 values it is top, right, bottom, left; 3 is top, right&left, bottom; 2 is top & bottom, right and left"`
 	Overflow       Overflow    `xml:"overflow" desc:"prop: overflow = what to do with content that overflows -- default is Auto add of scrollbars as needed -- todo: can have separate -x -y values"`
@@ -487,7 +487,7 @@ func (ly *Layout) GatherSizesGrid() {
 	rows := 0
 
 	sz := len(ly.Kids)
-	// collect overal size
+	// collect overall size
 	for _, c := range ly.Kids {
 		ni := c.(Node2D).AsWidget()
 		if ni == nil {

--- a/gi/menus.go
+++ b/gi/menus.go
@@ -345,7 +345,7 @@ func PopupMenu(menu Menu, x, y int, parVp *Viewport2D, name string) *Viewport2D 
 	pvp.SetFlag(int(VpFlagMenu))
 
 	pvp.Geom.Pos = image.Point{x, y}
-	// note: not setting VpFlagPopopDestroyAll -- we keep the menu list intact
+	// note: not setting VpFlagPopupDestroyAll -- we keep the menu list intact
 	frame := pvp.AddNewChild(KiT_Frame, "Frame").(*Frame)
 	frame.Lay = LayoutVert
 	frame.SetProps(MenuFrameProps, false)

--- a/gi/node.go
+++ b/gi/node.go
@@ -124,7 +124,7 @@ func (nb *NodeBase) HasNoLayout() bool {
 	return nb.HasFlag(int(NoLayout))
 }
 
-// CanFocus checks if this node can recieve keyboard focus
+// CanFocus checks if this node can receive keyboard focus
 func (nb *NodeBase) CanFocus() bool {
 	return nb.HasFlag(int(CanFocus))
 }

--- a/gi/paint.go
+++ b/gi/paint.go
@@ -67,7 +67,7 @@ type Paint struct {
 	FillStyle   FillStyle
 	FontStyle   FontStyle    `desc:"font also has global opacity setting, along with generic color, background-color settings, which can be copied into stroke / fill as needed"`
 	TextStyle   TextStyle    `desc:"font also has global opacity setting, along with generic color, background-color settings, which can be copied into stroke / fill as needed"`
-	VecEff      VectorEffect `xml:"vector-effect" desc:"prop: vector-effet = various rendering special effects settings"`
+	VecEff      VectorEffect `xml:"vector-effect" desc:"prop: vector-effect = various rendering special effects settings"`
 	XForm       Matrix2D     `xml:"transform" desc:"prop: transform = our additions to transform -- pushed to render state"`
 	dotsSet     bool
 	lastUnCtxt  units.Context
@@ -630,13 +630,13 @@ func (pc *Paint) Stroke(rs *RenderState) {
 }
 
 // FillPreserve fills the current path with the current color. Open subpaths
-// are implicity closed. The path is preserved after this operation.
+// are implicitly closed. The path is preserved after this operation.
 func (pc *Paint) FillPreserve(rs *RenderState) {
 	pc.fill(rs)
 }
 
 // Fill fills the current path with the current color. Open subpaths
-// are implicity closed. The path is cleared after this operation.
+// are implicitly closed. The path is cleared after this operation.
 func (pc *Paint) Fill(rs *RenderState) {
 	pc.FillPreserve(rs)
 	pc.ClearPath(rs)
@@ -788,7 +788,7 @@ func (pc *Paint) DrawRoundedRectangle(rs *RenderState, x, y, w, h, r float32) {
 	pc.ClosePath(rs)
 }
 
-// DrawElllipticalArc draws arc between angle1 and angle2 along an ellipse,
+// DrawEllipticalArc draws arc between angle1 and angle2 along an ellipse,
 // using quadratic bezier curves -- centers of ellipse are at cx, cy with
 // radii rx, ry -- see DrawEllipticalArcPath for a version compatible with SVG
 // A/a path drawing, which uses previous position instead of two angles
@@ -820,7 +820,7 @@ func (pc *Paint) DrawEllipticalArc(rs *RenderState, cx, cy, rx, ry, angle1, angl
 // in ellipse parametric when approximating an off-axis ellipse.
 const MaxDx float32 = math.Pi / 8
 
-// ellipsePrime gives tangent vectors for parameterized elipse; a, b, radii,
+// ellipsePrime gives tangent vectors for parameterized ellipse; a, b, radii,
 // eta parameter, center cx, cy
 func ellipsePrime(a, b, sinTheta, cosTheta, eta, cx, cy float32) (px, py float32) {
 	bCosEta := b * math32.Cos(eta)
@@ -830,7 +830,7 @@ func ellipsePrime(a, b, sinTheta, cosTheta, eta, cx, cy float32) (px, py float32
 	return
 }
 
-// ellipsePointAt gives points for parameterized elipse; a, b, radii, eta
+// ellipsePointAt gives points for parameterized ellipse; a, b, radii, eta
 // parameter, center cx, cy
 func ellipsePointAt(a, b, sinTheta, cosTheta, eta, cx, cy float32) (px, py float32) {
 	aCosEta := a * math32.Cos(eta)
@@ -896,13 +896,13 @@ func FindEllipseCenter(rx, ry *float32, rotX, startX, startY, endX, endY float32
 // returns in lx, ly the last points which are then set to the current cx, cy
 // for the path drawer
 func (pc *Paint) DrawEllipticalArcPath(rs *RenderState, cx, cy, ocx, ocy, pcx, pcy, rx, ry, angle float32, largeArc, sweep bool) (lx, ly float32) {
-	rotX := angle * math.Pi / 180 // Convert degress to radians
+	rotX := angle * math.Pi / 180 // Convert degrees to radians
 	startAngle := math32.Atan2(pcy-cy, pcx-cx) - rotX
 	endAngle := math32.Atan2(ocy-cy, ocx-cx) - rotX
 	deltaTheta := endAngle - startAngle
 	arcBig := math32.Abs(deltaTheta) > math.Pi
 
-	// Approximate ellipse using cubic bezeir splines
+	// Approximate ellipse using cubic bezier splines
 	etaStart := math32.Atan2(math32.Sin(startAngle)/ry, math32.Cos(startAngle)/rx)
 	etaEnd := math32.Atan2(math32.Sin(endAngle)/ry, math32.Cos(endAngle)/rx)
 	deltaEta := etaEnd - etaStart
@@ -913,7 +913,7 @@ func (pc *Paint) DrawEllipticalArcPath(rs *RenderState, cx, cy, ocx, ocy, pcx, p
 			deltaEta -= math.Pi * 2
 		}
 	}
-	// This check might be needed if the center point of the elipse is
+	// This check might be needed if the center point of the ellipse is
 	// at the midpoint of the start and end lines.
 	if deltaEta < 0 && sweep {
 		deltaEta += math.Pi * 2
@@ -927,7 +927,7 @@ func (pc *Paint) DrawEllipticalArcPath(rs *RenderState, cx, cy, ocx, ocy, pcx, p
 	// Approximate the ellipse using a set of cubic bezier curves by the method of
 	// L. Maisonobe, "Drawing an elliptical arc using polylines, quadratic
 	// or cubic Bezier curves", 2003
-	// https://www.spaceroots.org/documents/elllipse/elliptical-arc.pdf
+	// https://www.spaceroots.org/documents/ellipse/elliptical-arc.pdf
 	tde := math32.Tan(dEta / 2)
 	alpha := math32.Sin(dEta) * (math32.Sqrt(4+3*tde*tde) - 1) / 3 // Math is fun!
 	lx, ly = pcx, pcy

--- a/gi/prefs.go
+++ b/gi/prefs.go
@@ -20,7 +20,7 @@ import (
 	"github.com/goki/ki/kit"
 )
 
-// FileName is used to specify an filename (including path) -- automtically
+// FileName is used to specify an filename (including path) -- automatically
 // opens the FileView dialog using ValueView system.  Use this for any method
 // args that are filenames to trigger use of FileViewDialog under MethView
 // automatic method calling.
@@ -78,7 +78,7 @@ type Preferences struct {
 	SaveKeyMaps          bool                   `desc:"if set, the current available set of key maps is saved to your preferences directory, and automatically loaded at startup -- this should be set if you are using custom key maps, but it may be safer to keep it <i>OFF</i> if you are <i>not</i> using custom key maps, so that you'll always have the latest compiled-in standard key maps with all the current key functions bound to standard key chords"`
 	SaveDetailed         bool                   `desc:"if set, the detailed preferences are saved and loaded at startup -- only "`
 	CustomStyles         ki.Props               `desc:"a custom style sheet -- add a separate Props entry for each type of object, e.g., button, or class using .classname, or specific named element using #name -- all are case insensitive"`
-	CustomStylesOverride bool                   `desc:"if true my custom styles override other styling (i.e., they come <i>last</i> in styling process -- otherwise they provide defaults that can be overriden by app-specific styling (i.e, they come first)."`
+	CustomStylesOverride bool                   `desc:"if true my custom styles override other styling (i.e., they come <i>last</i> in styling process -- otherwise they provide defaults that can be overridden by app-specific styling (i.e, they come first)."`
 	FontFamily           FontName               `desc:"default font family when otherwise not specified"`
 	FontPaths            []string               `desc:"extra font paths, beyond system defaults -- searched first"`
 	User                 User                   `desc:"user info -- partially filled-out automatically if empty / when prefs first created"`
@@ -129,7 +129,7 @@ func (pf *ColorPrefs) PrefColor(clrName string) *Color {
 	case "link":
 		return &pf.Link
 	}
-	log.Printf("Preference color %v (simlified to: %v) not found\n", clrName, lc)
+	log.Printf("Preference color %v (simplified to: %v) not found\n", clrName, lc)
 	return nil
 }
 

--- a/gi/sliders.go
+++ b/gi/sliders.go
@@ -43,7 +43,7 @@ type SliderBase struct {
 	DragPos     float32              `xml:"-" desc:"underlying drag position of slider -- not subject to snapping"`
 	VisPos      float32              `xml:"vispos" desc:"visual position of the slider -- can be different from pos in a RTL environment"`
 	Dim         Dims2D               `desc:"dimension along which the slider slides"`
-	Tracking    bool                 `xml:"tracking" desc:"if true, will send continuous updates of value changes as user moves the slider -- otherwise only at the end -- see ThrackThr for a threshold on amount of change"`
+	Tracking    bool                 `xml:"tracking" desc:"if true, will send continuous updates of value changes as user moves the slider -- otherwise only at the end -- see TrackThr for a threshold on amount of change"`
 	TrackThr    float32              `xml:"track-thr" desc:"threshold for amount of change in scroll value before emitting a signal in Tracking mode"`
 	Snap        bool                 `xml:"snap" desc:"snap the values to Step size increments"`
 	State       SliderStates         `json:"-" xml:"-" desc:"state of slider"`
@@ -276,7 +276,7 @@ func (sb *SliderBase) SetValueAction(val float32) {
 	sb.SliderSig.Emit(sb.This(), int64(SliderValueChanged), sb.Value)
 }
 
-// SetThumValue sets the thumb value to given value and updates the thumb size
+// SetThumbValue sets the thumb value to given value and updates the thumb size
 // -- for scrollbar-style sliders where the thumb size represents visible range
 func (sb *SliderBase) SetThumbValue(val float32) {
 	updt := sb.UpdateStart()

--- a/gi/splitview.go
+++ b/gi/splitview.go
@@ -23,10 +23,10 @@ import (
 // SplitView allocates a fixed proportion of space to each child, along given
 // dimension, always using only the available space given to it by its parent
 // (i.e., it will force its children, which should be layouts (typically
-// Frame's), to have their own scroll bars as necesssary).  It should
+// Frame's), to have their own scroll bars as necessary).  It should
 // generally be used as a main outer-level structure within a window,
 // providing a framework for inner elements -- it allows individual child
-// elements to update indpendently and thus is important for speeding update
+// elements to update independently and thus is important for speeding update
 // performance.  It uses the Widget Parts to hold the splitter widgets
 // separately from the children that contain the rest of the scenegraph to be
 // displayed within each region.

--- a/gi/style.go
+++ b/gi/style.go
@@ -178,7 +178,7 @@ type ShadowStyle struct {
 	HOffset units.Value `xml:".h-offset" desc:"prop: .h-offset = horizontal offset of shadow -- positive = right side, negative = left side"`
 	VOffset units.Value `xml:".v-offset" desc:"prop: .v-offset = vertical offset of shadow -- positive = below, negative = above"`
 	Blur    units.Value `xml:".blur" desc:"prop: .blur = blur radius -- higher numbers = more blurry"`
-	Spread  units.Value `xml:".spread" desc:"prop: .spread = spread radius -- positive number increases size of shadow, negative descreases size"`
+	Spread  units.Value `xml:".spread" desc:"prop: .spread = spread radius -- positive number increases size of shadow, negative decreases size"`
 	Color   Color       `xml:".color" desc:"prop: .color = color of the shadow"`
 	Inset   bool        `xml:".inset" desc:"prop: .inset = shadow is inset within box instead of outset outside of box"`
 }

--- a/gi/style_test.go
+++ b/gi/style_test.go
@@ -34,7 +34,7 @@ func TestStyle(t *testing.T) {
 
 	fmt.Printf("style width: %v\n", s.Layout.Width)
 	fmt.Printf("style height: %v\n", s.Layout.Height)
-	fmt.Printf("style box-shaodw.h-offset: %v\n", s.BoxShadow.HOffset)
-	fmt.Printf("style box-shaodw.v-offset: %v\n", s.BoxShadow.VOffset)
+	fmt.Printf("style box-shadow.h-offset: %v\n", s.BoxShadow.HOffset)
+	fmt.Printf("style box-shadow.v-offset: %v\n", s.BoxShadow.VOffset)
 	fmt.Printf("style border-style: %v\n", s.Border.Style)
 }

--- a/gi/text.go
+++ b/gi/text.go
@@ -333,7 +333,7 @@ func (sr *SpanRender) SetString(str string, sty *FontStyle, ctxt *units.Context,
 }
 
 // SetRunes initializes to given plain rune string, with given default style
-// arameters that are set for the first render element -- constructs Render
+// parameters that are set for the first render element -- constructs Render
 // slice of same size as Text
 func (sr *SpanRender) SetRunes(str []rune, sty *FontStyle, ctxt *units.Context, noBG bool, rot, scalex float32) {
 	sr.Text = str
@@ -342,7 +342,7 @@ func (sr *SpanRender) SetRunes(str []rune, sty *FontStyle, ctxt *units.Context, 
 
 // TextFontRenderMu mutex is required because multiple different goroutines
 // associated with different windows can (and often will be) call font stuff
-// at the same time (curFace.GyphAdvance, rendering font) at the same time, on
+// at the same time (curFace.GlyphAdvance, rendering font) at the same time, on
 // the same font face -- and that turns out not to work!
 var TextFontRenderMu sync.Mutex
 
@@ -599,7 +599,7 @@ func (sr *SpanRender) LastFont() (face font.Face, color color.Color) {
 type TextLink struct {
 	Label     string   `desc:"text label for the link"`
 	URL       string   `desc:"full URL for the link"`
-	Props     ki.Props `desc:"proerties defined for the link"`
+	Props     ki.Props `desc:"properties defined for the link"`
 	StartSpan int      `desc:"span index where link starts"`
 	StartIdx  int      `desc:"index in StartSpan where link starts"`
 	EndSpan   int      `desc:"span index where link ends (can be same as EndSpan)"`
@@ -1600,7 +1600,7 @@ type TextStyle struct {
 	OrientationVert  float32        `xml:"glyph-orientation-vertical" inherit:"true" desc:"prop: glyph-orientation-vertical = for TBRL writing mode (only), determines orientation of alphabetic characters -- 90 is default (rotated) -- 0 means keep upright"`
 	OrientationHoriz float32        `xml:"glyph-orientation-horizontal" inherit:"true" desc:"prop: glyph-orientation-horizontal = for horizontal LR/RL writing mode (only), determines orientation of all characters -- 0 is default (upright)"`
 	Indent           units.Value    `xml:"text-indent" inherit:"true" desc:"prop: text-indent = how much to indent the first line in a paragraph"`
-	ParaSpacing      units.Value    `xml:"para-spacing" inherit:"true" desc:"prop: para-spacing = extra spacing between paragraphs -- copied from Style.Layout.Margin per CSS spec if that is non-zero, else can be set directy with para-spacing"`
+	ParaSpacing      units.Value    `xml:"para-spacing" inherit:"true" desc:"prop: para-spacing = extra spacing between paragraphs -- copied from Style.Layout.Margin per CSS spec if that is non-zero, else can be set directly with para-spacing"`
 	TabSize          int            `xml:"tab-size" inherit:"true" desc:"prop: tab-size = tab size, in number of characters"`
 	// todo:
 	// page-break options

--- a/gi/textfield.go
+++ b/gi/textfield.go
@@ -540,7 +540,7 @@ func (tf *TextField) DeleteSelection() string {
 }
 
 // Copy copies any selected text to the clipboard, and returns that text,
-// optionaly resetting the current selection
+// optionally resetting the current selection
 func (tf *TextField) Copy(reset bool) string {
 	wupdt := tf.Viewport.Win.UpdateStart()
 	defer tf.Viewport.Win.UpdateEnd(wupdt)

--- a/gi/viewport2d.go
+++ b/gi/viewport2d.go
@@ -51,7 +51,7 @@ var Viewport2DProps = ki.Props{
 }
 
 // NewViewport2D creates a new OSImage with the specified width and height,
-// and intializes the renderer etc
+// and initializes the renderer etc
 func NewViewport2D(width, height int) *Viewport2D {
 	sz := image.Point{width, height}
 	vp := &Viewport2D{
@@ -172,7 +172,7 @@ func (vp *Viewport2D) IsVisible() bool {
 // set our window pointer to point to the current window we are under
 func (vp *Viewport2D) SetCurWin() {
 	pwin := vp.ParentWindow()
-	if pwin != nil { // ony update if non-nil -- otherwise we could be setting
+	if pwin != nil { // only update if non-nil -- otherwise we could be setting
 		// temporarily to give access to DPI etc
 		vp.Win = pwin
 	}
@@ -299,7 +299,7 @@ func (vp *Viewport2D) AsViewport2D() *Viewport2D {
 func (vp *Viewport2D) Init2D() {
 	vp.Init2DWidget()
 	vp.SetCurWin()
-	// we update oursleves whenever any node update event happens
+	// we update ourselves whenever any node update event happens
 	vp.NodeSig.Connect(vp.This(), func(recvp, sendvp ki.Ki, sig int64, data interface{}) {
 		rvpi, _ := KiToNode2D(recvp)
 		rvp := rvpi.AsViewport2D()

--- a/gi/views.go
+++ b/gi/views.go
@@ -35,7 +35,7 @@ type ViewIFace interface {
 	PrefsDetView(prefs *PrefsDetailed)
 
 	// HiStylesView opens an interactive view of given highlighting styles
-	// (pased as interface due to package inclusion issues)
+	// (passed as interface due to package inclusion issues)
 	HiStylesView(styles interface{})
 
 	// PrefsDetDefaults gets current detailed prefs values as defaults
@@ -48,5 +48,5 @@ type ViewIFace interface {
 	PrefsDbgView(prefs *PrefsDebug)
 }
 
-// TheViewIFace is the implemenation of the interface, defined in giv package
+// TheViewIFace is the implementation of the interface, defined in giv package
 var TheViewIFace ViewIFace

--- a/gi/widget.go
+++ b/gi/widget.go
@@ -566,7 +566,7 @@ func (wb *WidgetBase) HoverTooltipEvent() {
 	})
 }
 
-// WidgetMouseEvents connects to eiher or both mouse events -- IMPORTANT: if
+// WidgetMouseEvents connects to either or both mouse events -- IMPORTANT: if
 // you need to also connect to other mouse events, you must copy this code --
 // all processing of a mouse event must happen within one function b/c there
 // can only be one registered per receiver and event type.  sel = Left button
@@ -728,7 +728,7 @@ func (wb *WidgetBase) SetFixedHeight(val units.Value) {
 // PartsWidgetBase
 
 // PartsWidgetBase is the base type for all Widget Node2D elements that manage
-// a set of constitutent parts
+// a set of constituent parts
 type PartsWidgetBase struct {
 	WidgetBase
 	Parts Layout `json:"-" xml:"-" view-closed:"true" desc:"a separate tree of sub-widgets that implement discrete parts of a widget -- positions are always relative to the parent widget -- fully managed by the widget and not saved"`
@@ -740,7 +740,7 @@ var PartsWidgetBaseProps = ki.Props{
 	"base-type": true,
 }
 
-// standard FunDownMeFirst etc operate automaticaly on Field structs such as
+// standard FunDownMeFirst etc operate automatically on Field structs such as
 // Parts -- custom calls only needed for manually-recursive traversal in
 // Layout and Render
 

--- a/gi/window.go
+++ b/gi/window.go
@@ -145,14 +145,14 @@ type Window struct {
 	DNDFinalEvent     *dnd.Event                              `json:"-" xml:"-" view:"-" desc:"final event for DND which is sent if a finalize is received"`
 	Dragging          ki.Ki                                   `json:"-" xml:"-" desc:"node receiving mouse dragging events -- not for DND but things like sliders -- anchor to same"`
 	Scrolling         ki.Ki                                   `json:"-" xml:"-" desc:"node receiving mouse scrolling events -- anchor to same"`
-	Popup             ki.Ki                                   `jsom:"-" xml:"-" desc:"Current popup viewport that gets all events"`
-	PopupStack        []ki.Ki                                 `jsom:"-" xml:"-" desc:"stack of popups"`
-	FocusStack        []ki.Ki                                 `jsom:"-" xml:"-" desc:"stack of focus"`
+	Popup             ki.Ki                                   `json:"-" xml:"-" desc:"Current popup viewport that gets all events"`
+	PopupStack        []ki.Ki                                 `json:"-" xml:"-" desc:"stack of popups"`
+	FocusStack        []ki.Ki                                 `json:"-" xml:"-" desc:"stack of focus"`
 	NextPopup         ki.Ki                                   `json:"-" xml:"-" desc:"this popup will be pushed at the end of the current event cycle -- use SetNextPopup"`
 	PopupFocus        ki.Ki                                   `json:"-" xml:"-" desc:"node to focus on when next popup is activated -- use SetNextPopup"`
 	DelPopup          ki.Ki                                   `json:"-" xml:"-" desc:"this popup will be popped at the end of the current event cycle -- use SetDelPopup"`
 	PopMu             sync.RWMutex                            `json:"-" xml:"-" view:"-" desc:"read-write mutex that protects popup updating and access"`
-	TimerMu           sync.Mutex                              `json:"-" xml:"-" view:"-" desc:"mutex that protects timer variable updates (e.g., hover AferFunc's)"`
+	TimerMu           sync.Mutex                              `json:"-" xml:"-" view:"-" desc:"mutex that protects timer variable updates (e.g., hover AfterFunc's)"`
 	lastWinMenuUpdate time.Time
 }
 
@@ -187,7 +187,7 @@ const (
 
 // these extend NodeBase NodeFlags to hold Window state
 const (
-	// WinFlagHasGeomPrefs indicates if this window has WinGeomPrefs setting that sized it -- affects whether other defauld geom should be applied
+	// WinFlagHasGeomPrefs indicates if this window has WinGeomPrefs setting that sized it -- affects whether other default geom should be applied
 	WinFlagHasGeomPrefs NodeFlags = NodeFlagsN + iota
 
 	// WinFlagUpdating is atomic flag around global updating -- routines can check IsWinUpdating and bail
@@ -705,7 +705,7 @@ func (w *Window) StopEventLoop() {
 }
 
 // ConnectEvent adds a Signal connection for given event type and
-// prioritiy to given receiver
+// priority to given receiver
 func (w *Window) ConnectEvent(recv ki.Ki, et oswin.EventType, pri EventPris, fun ki.RecvFunc) {
 	if et >= oswin.EventTypeN {
 		log.Printf("Window ConnectEvent type: %v is not a known event type\n", et)
@@ -1046,7 +1046,7 @@ func (w *Window) AddSprite(nm string, sz image.Point, pos image.Point) *Viewport
 }
 
 // ActivateSprite clears the Inactive flag on the sprite, and increments
-// ActiveSprites, so that it will actualy be rendered
+// ActiveSprites, so that it will actually be rendered
 func (w *Window) ActivateSprite(nm string) {
 	w.UpMu.Lock()
 	defer w.UpMu.Unlock()
@@ -2024,7 +2024,7 @@ func (w *Window) AddShortcut(chord key.Chord, act *Action) {
 }
 
 // TriggerShortcut attempts to trigger a shortcut, returning true if one was
-// triggered, and false otherwise.  Also elminates any shortcuts with deleted
+// triggered, and false otherwise.  Also eliminates any shortcuts with deleted
 // actions, and does not trigger for Inactive actions.
 func (w *Window) TriggerShortcut(chord key.Chord) bool {
 	if KeyEventTrace {
@@ -2167,7 +2167,7 @@ func (w *Window) ShouldDeletePopupMenu(pop ki.Ki, me *mouse.Event) bool {
 	if !PopupIsMenu(pop) {
 		return false
 	}
-	if w.NextPopup != nil && PopupIsMenu(w.NextPopup) { // poping up another menu
+	if w.NextPopup != nil && PopupIsMenu(w.NextPopup) { // popping up another menu
 		return false
 	}
 	if me.Button != mouse.Left && w.Dragging == nil { // probably menu activation in first place
@@ -2647,7 +2647,7 @@ func (w *Window) FocusActiveClick(e *mouse.Event) {
 		return
 	}
 	cpop := w.CurPopup()
-	if cpop != nil { // no updating on popus
+	if cpop != nil { // no updating on popups
 		return
 	}
 	nii, ni := KiToNode2D(cfoc)
@@ -2884,7 +2884,7 @@ func (w *Window) DNDNotCursor() {
 	oswin.TheApp.Cursor(w.OSWin).PushIfNot(cursor.Not)
 }
 
-// DNDUpdateCursor updates the cursor based on the curent DND event mod if
+// DNDUpdateCursor updates the cursor based on the current DND event mod if
 // different from current (but no update if Not)
 func (w *Window) DNDUpdateCursor(dmod dnd.DropMods) bool {
 	dndc := DNDModCursor(dmod)

--- a/giv/dialogs.go
+++ b/giv/dialogs.go
@@ -328,7 +328,7 @@ func ColorViewDialogValue(dlg *gi.Dialog) gi.Color {
 }
 
 // FileViewDialog is for selecting / manipulating files -- ext is one or more
-// (comma separated) extensions -- files with those will be highighted
+// (comma separated) extensions -- files with those will be highlighted
 // (include the . at the start of the extension).  recv and dlgFunc connect to the
 // dialog signal: if signal value is gi.DialogAccepted use FileViewDialogValue
 // to get the resulting selected file.  The optional filterFunc can filter

--- a/giv/fileinfo.go
+++ b/giv/fileinfo.go
@@ -208,7 +208,7 @@ func MimeFromFile(fname string) (mtype, ext string, err error) {
 	return "", ext, fmt.Errorf("giv.MimeFromFile could not find mime type for ext: %v file: %v", ext, fname)
 }
 
-// FileKindFromMime returns simplfied Kind description based on the given full
+// FileKindFromMime returns simplified Kind description based on the given full
 // mime type string.  Strips out application/ prefix, and converts all the
 // chroma-based mime-types to their basic names
 func FileKindFromMime(mime string) string {

--- a/giv/filetree.go
+++ b/giv/filetree.go
@@ -575,7 +575,7 @@ type FileSearchMatch struct {
 var FileSearchContext = 30
 
 // FileSearch looks for a string (no regexp) within a file, in a
-// case-sensitive way, returning number of occurences and specific match
+// case-sensitive way, returning number of occurrences and specific match
 // position list -- column positions are in bytes, not runes.
 func FileSearch(filename string, find []byte, ignoreCase bool) (int, []FileSearchMatch) {
 	fp, err := os.Open(filename)
@@ -588,7 +588,7 @@ func FileSearch(filename string, find []byte, ignoreCase bool) (int, []FileSearc
 }
 
 // ByteBufSearch looks for a string (no regexp) within a byte buffer, with
-// given case-sensitivity, returning number of occurences and specific match
+// given case-sensitivity, returning number of occurrences and specific match
 // position list -- column positions are in bytes, not runes.
 func ByteBufSearch(reader io.Reader, find []byte, ignoreCase bool) (int, []FileSearchMatch) {
 	fsz := len(find)

--- a/giv/fileview.go
+++ b/giv/fileview.go
@@ -82,7 +82,7 @@ func (fv *FileView) SetFilename(filename, ext string) {
 	fv.DoStdConfig()
 }
 
-// SetPathFile sets the path, initial select file (or "") and intializes the view
+// SetPathFile sets the path, initial select file (or "") and initializes the view
 func (fv *FileView) SetPathFile(path, file, ext string) {
 	fv.DirPath = path
 	fv.SelFile = file

--- a/giv/himarkup.go
+++ b/giv/himarkup.go
@@ -118,7 +118,7 @@ type HiMarkup struct {
 	style     histyle.Style
 }
 
-// HasHi returns true if there are highighting parameters set (only valid after Init)
+// HasHi returns true if there are highlighting parameters set (only valid after Init)
 func (hm *HiMarkup) HasHi() bool {
 	return hm.Has
 }

--- a/giv/methview.go
+++ b/giv/methview.go
@@ -222,7 +222,7 @@ func CallMethod(val interface{}, method string, vp *gi.Viewport2D) bool {
 
 	acp, has := cmp[method]
 	if !has {
-		MethViewErr(vtyp, fmt.Sprintf("Method: %v not found among all different methods registered on type propertis -- add to CallMethods to make available for CallMethod\n", method))
+		MethViewErr(vtyp, fmt.Sprintf("Method: %v not found among all different methods registered on type properties -- add to CallMethods to make available for CallMethod\n", method))
 		return false
 	}
 	ac, ok := acp.(*gi.Action)

--- a/giv/textbuf.go
+++ b/giv/textbuf.go
@@ -43,7 +43,7 @@ type TextBufOpts struct {
 // syntax highlighting), and sends signals for making edits to the text and
 // coordinating those edits across multiple views.  Views always only view a
 // single buffer, so they directly call methods on the buffer to drive
-// updates, which are then broadast.  It also has methods for loading and
+// updates, which are then broadcast.  It also has methods for loading and
 // saving buffers to files.  Unlike GUI Widgets, its methods are generally
 // signaling, without an explicit Action suffix.  Internally, the buffer
 // represents new lines using \n = LF, but saving and loading can deal with
@@ -861,7 +861,7 @@ func (tb *TextBuf) BytesToLines() {
 //   Search
 
 // Search looks for a string (no regexp) within buffer, with given case-sensitivity
-// returning number of occurences and specific match position list.
+// returning number of occurrences and specific match position list.
 // Currently ONLY returning byte char positions, not rune ones..
 func (tb *TextBuf) Search(find []byte, ignoreCase bool) (int, []FileSearchMatch) {
 	fsz := len(find)
@@ -1256,7 +1256,7 @@ func (tb *TextBuf) DeleteText(st, ed TextPos, saveUndo, signal bool) *TextBufEdi
 }
 
 // Insert inserts new text at given starting position, signaling views after
-// text has been inserted.  Sets the timestamp on resutling TextBufEdit to now
+// text has been inserted.  Sets the timestamp on resulting TextBufEdit to now
 func (tb *TextBuf) InsertText(st TextPos, text []byte, saveUndo, signal bool) *TextBufEdit {
 	if len(text) == 0 {
 		return nil

--- a/giv/textview.go
+++ b/giv/textview.go
@@ -56,12 +56,12 @@ type TextView struct {
 	SelectStart   TextPos                   `json:"-" xml:"-" desc:"starting point for selection -- will either be the start or end of selected region depending on subsequent selection."`
 	SelectReg     TextRegion                `json:"-" xml:"-" desc:"current selection region"`
 	PrevSelectReg TextRegion                `json:"-" xml:"-" desc:"previous selection region, that was actually rendered -- needed to update render"`
-	Highlights    []TextRegion              `json:"-" xml:"-" desc:"highlighed regions, e.g., for search results"`
+	Highlights    []TextRegion              `json:"-" xml:"-" desc:"highlighted regions, e.g., for search results"`
 	SelectMode    bool                      `json:"-" xml:"-" desc:"if true, select text as cursor moves"`
 	ForceComplete bool                      `json:"-" xml:"-" desc:"if true, complete regardless of any disqualifying reasons"`
 	ISearch       ISearch                   `json:"-" xml:"-" desc:"interactive search data"`
 	QReplace      QReplace                  `json:"-" xml:"-" desc:"query replace data"`
-	TextViewSig   ki.Signal                 `json:"-" xml:"-" view:"-" desc:"signal for text viewt -- see TextViewSignals for the types"`
+	TextViewSig   ki.Signal                 `json:"-" xml:"-" view:"-" desc:"signal for text view -- see TextViewSignals for the types"`
 	LinkSig       ki.Signal                 `json:"-" xml:"-" view:"-" desc:"signal for clicking on a link -- data is a string of the URL -- if nobody receiving this signal, calls TextLinkHandler then URLHandler"`
 	StateStyles   [TextViewStatesN]gi.Style `json:"-" xml:"-" desc:"normal style and focus style"`
 	FontHeight    float32                   `json:"-" xml:"-" desc:"font height, cached during styling"`
@@ -244,7 +244,7 @@ func (tv *TextView) ClearNeedsRefresh() {
 }
 
 // RefreshIfNeeded re-displays everything if SetNeedsRefresh was called --
-// returns true if refrehshed
+// returns true if refreshed
 func (tv *TextView) RefreshIfNeeded() bool {
 	if tv.NeedsRefresh() {
 		tv.Refresh()
@@ -2199,7 +2199,7 @@ func (tv *TextView) DeleteSelection() *TextBufEdit {
 }
 
 // Copy copies any selected text to the clipboard, and returns that text,
-// optionaly resetting the current selection
+// optionally resetting the current selection
 func (tv *TextView) Copy(reset bool) *TextBufEdit {
 	updt := tv.Viewport.Win.UpdateStart()
 	defer tv.Viewport.Win.UpdateEnd(updt)

--- a/giv/treeview.go
+++ b/giv/treeview.go
@@ -807,7 +807,7 @@ func (tv *TreeView) IsRootOrField(op string) bool {
 }
 
 // SrcInsertAfter inserts a new node in the source tree after this node, at
-// the same (sibling) level, propmting for the type of node to insert
+// the same (sibling) level, prompting for the type of node to insert
 func (tv *TreeView) SrcInsertAfter() {
 	ttl := "Insert After"
 	if tv.IsRootOrField(ttl) {
@@ -871,7 +871,7 @@ func (tv *TreeView) SrcInsertBefore() {
 }
 
 // SrcAddChild adds a new child node to this one in the source tree,
-// propmpting the user for the type of node to add
+// prompting the user for the type of node to add
 func (tv *TreeView) SrcAddChild() {
 	ttl := "Add Child"
 	gi.NewKiDialog(tv.Viewport, reflect.TypeOf((*gi.Node2D)(nil)).Elem(),

--- a/giv/valueview.go
+++ b/giv/valueview.go
@@ -46,7 +46,7 @@ type ValueViewer interface {
 	ValueView() ValueView
 }
 
-// example implementation of ValueViewer interface -- can't implment on
+// example implementation of ValueViewer interface -- can't implement on
 // non-local types, so all the basic types are handled separately:
 //
 // func (s string) ValueView() ValueView {
@@ -309,7 +309,7 @@ func FieldToValueView(it interface{}, field string, fval interface{}) ValueView 
 // (e.g., fields, map values, slice values) in Views (StructView, MapView,
 // etc).  The different types of ValueView are for different Kinds of values
 // (bool, float, etc) -- which can have different Kinds of owners.  The
-// ValueVuewBase class supports all the basic fields for managing the owner
+// ValueViewBase class supports all the basic fields for managing the owner
 // kinds.
 type ValueView interface {
 	ki.Ki

--- a/histyle/histyle.go
+++ b/histyle/histyle.go
@@ -49,7 +49,7 @@ var KiT_Trilean = kit.Enums.AddEnumAltLower(TrileanN, false, nil, "")
 func (ev Trilean) MarshalJSON() ([]byte, error)  { return kit.EnumMarshalJSON(ev) }
 func (ev *Trilean) UnmarshalJSON(b []byte) error { return kit.EnumUnmarshalJSON(ev, b) }
 
-// StyleEntry is one value in the map of highilight style values
+// StyleEntry is one value in the map of highlight style values
 type StyleEntry struct {
 	Color      gi.Color `desc:"text color"`
 	Background gi.Color `desc:"background color"`
@@ -57,7 +57,7 @@ type StyleEntry struct {
 	Bold       Trilean  `desc:"bold font"`
 	Italic     Trilean  `desc:"italic font"`
 	Underline  Trilean  `desc:"underline"`
-	NoInherit  bool     `desc:"don't inherit these settings from sub-category or category levels -- otherwise everthing with a Pass is inherited"`
+	NoInherit  bool     `desc:"don't inherit these settings from sub-category or category levels -- otherwise everything with a Pass is inherited"`
 }
 
 var KiT_StyleEntry = kit.Types.AddType(&StyleEntry{}, StyleEntryProps)

--- a/histyle/hitags.go
+++ b/histyle/hitags.go
@@ -136,7 +136,7 @@ const (
 	LineNumbers
 	// Line numbers in output when in table.
 	LineNumbersTable
-	// Line higlight style.
+	// Line highlight style.
 	LineHighlight
 	// Line numbers table wrapper style.
 	LineTable

--- a/oswin/app.go
+++ b/oswin/app.go
@@ -67,7 +67,7 @@ type App interface {
 	NewWindow(opts *NewWindowOptions) (Window, error)
 
 	// NewImage returns a new Image for this screen.  Images can be drawn upon
-	// directly using image and other packages, and have an accessable []byte
+	// directly using image and other packages, and have an accessible []byte
 	// slice holding the image data.
 	NewImage(size image.Point) (Image, error)
 
@@ -111,12 +111,12 @@ type App interface {
 	// xdg-open command.
 	OpenURL(url string)
 
-	// SetQuitReqFunc sets the function that is called whenver there is a
+	// SetQuitReqFunc sets the function that is called whenever there is a
 	// request to quit the app (via a OS or a call to QuitReq() method).  That
 	// function can then adjudicate whether and when to actually call Quit.
 	SetQuitReqFunc(fun func())
 
-	// SetQuitCleanFunc sets the function that is called whenver app is
+	// SetQuitCleanFunc sets the function that is called whenever app is
 	// actually about to quit (irrevocably) -- can do any necessary
 	// last-minute cleanup here.
 	SetQuitCleanFunc(fun func())

--- a/oswin/doc.go
+++ b/oswin/doc.go
@@ -14,9 +14,9 @@
 // The App interface provides a top-level, single-instance struct that knows
 // about specific hardware, and can create new Window, Image, and Texture
 // objects that are hardware-specific and provide the primary GUI interface.
-// It is aways available as oswin.TheApp.
+// It is always available as oswin.TheApp.
 //
-// Events are commuinicated through the Window -- see EventType and Event in
+// Events are communicated through the Window -- see EventType and Event in
 // event.go for all the different types.
 //
 // The driver package creates the App, via its Main function, which is

--- a/oswin/driver/macdriver/cocoa.go
+++ b/oswin/driver/macdriver/cocoa.go
@@ -489,7 +489,7 @@ func mouseEvent(id uintptr, x, y, dx, dy float32, ty, button int32, flags uint32
 		// can produce wheel events in opposite directions, but the
 		// direction matches what other programs on the OS do.
 		//
-		// If we wanted to expose the phsyical device motion in the
+		// If we wanted to expose the physical device motion in the
 		// event we could use [NSEvent isDirectionInvertedFromDevice]
 		// to know if "natural scrolling" is enabled.
 		event = &mouse.ScrollEvent{

--- a/oswin/driver/windriver/app.go
+++ b/oswin/driver/windriver/app.go
@@ -387,7 +387,7 @@ func sendQuit(hwnd syscall.Handle, uMsg uint32, wParam, lParam uintptr) (lResult
 }
 
 //////////////////////////////////////////////////////////////////
-//   Windows utilties
+//   Windows utilities
 
 ////////////////////////////////////////////////////////
 // appWND is the handle to the "AppWindow".  The window encapsulates all

--- a/oswin/driver/windriver/window.go
+++ b/oswin/driver/windriver/window.go
@@ -344,7 +344,7 @@ var msgCmd = AddWindowMsg(handleCmd)
 func (w *windowImpl) execCmd(c *cmd) {
 	SendMessage(w.hwnd, msgCmd, 0, uintptr(unsafe.Pointer(c)))
 	if c.err != nil {
-		panic(fmt.Sprintf("execCmd faild for cmd.id=%d: %v", c.id, c.err)) // TODO handle errors
+		panic(fmt.Sprintf("execCmd failed for cmd.id=%d: %v", c.id, c.err)) // TODO handle errors
 	}
 }
 

--- a/oswin/driver/x11driver/window.go
+++ b/oswin/driver/x11driver/window.go
@@ -166,7 +166,7 @@ func AbsInt(a int) int {
 }
 
 func (w *windowImpl) handleConfigureNotify(ev xproto.ConfigureNotifyEvent) {
-	// todo: support multple screens
+	// todo: support multiple screens
 	sc := oswin.TheApp.Screen(0)
 	dpi := sc.PhysicalDPI
 

--- a/oswin/event.go
+++ b/oswin/event.go
@@ -13,7 +13,7 @@ import (
 	"github.com/goki/ki/nptime"
 )
 
-// GoGi event structure is dervied from go.wde and golang/x/mobile/event
+// GoGi event structure is derived from go.wde and golang/x/mobile/event
 //
 // GoGi requires event type enum for widgets to request what events to
 // receive, and we add an overall interface with base support for time and

--- a/oswin/mimedata/mimedata.go
+++ b/oswin/mimedata/mimedata.go
@@ -56,7 +56,7 @@ var (
 	TextXML = "text/xml"
 
 	ImageAny  = "image/*"
-	ImageJPEG = "image/jepg"
+	ImageJPEG = "image/jpeg"
 	ImagePNG  = "image/png"
 	ImageGIF  = "image/gif"
 	ImageTIFF = "image/tiff"

--- a/oswin/mouse/mouse.go
+++ b/oswin/mouse/mouse.go
@@ -220,7 +220,7 @@ const (
 	// select a continuous region of selected items, with no gaps
 	ExtendContinuous
 
-	// ExtendOne, activated by Control or Meta / Commmand, extends the
+	// ExtendOne, activated by Control or Meta / Command, extends the
 	// selection by adding the one additional item just clicked on, creating a
 	// potentially discontinuous set of selected items
 	ExtendOne

--- a/oswin/window.go
+++ b/oswin/window.go
@@ -56,7 +56,7 @@ type Window interface {
 	// is the only supported mechanism for de-iconifying.
 	Raise()
 
-	// Minimize requests that the window be iconfied, making it no longer
+	// Minimize requests that the window be iconified, making it no longer
 	// visible or active -- rendering should not occur for minimized windows.
 	Minimize()
 
@@ -118,12 +118,12 @@ type Window interface {
 	// input etc).
 	IsFocus() bool
 
-	// SetCloseReqFunc sets the function that is called whenver there is a
+	// SetCloseReqFunc sets the function that is called whenever there is a
 	// request to close the window (via a OS or a call to CloseReq() method).  That
 	// function can then adjudicate whether and when to actually call Close.
 	SetCloseReqFunc(fun func(win Window))
 
-	// SetCloseCleanFunc sets the function that is called whenver window is
+	// SetCloseCleanFunc sets the function that is called whenever window is
 	// actually about to close (irrevocably) -- can do any necessary
 	// last-minute cleanup here.
 	SetCloseCleanFunc(fun func(win Window))

--- a/svg/icons.go
+++ b/svg/icons.go
@@ -47,7 +47,7 @@ var IconProps = ki.Props{
 }
 
 // CopyFromIcon copies from a source icon, typically one from a library --
-// preserves all the exisiting render state etc for the current icon, so that
+// preserves all the existing render state etc for the current icon, so that
 // only a new render is required
 func (ic *Icon) CopyFromIcon(cp *Icon) {
 	if cp == nil {

--- a/svg/marker.go
+++ b/svg/marker.go
@@ -42,7 +42,7 @@ var KiT_MarkerUnits = kit.Enums.AddEnumAltLower(MarkerUnitsN, false, gi.StylePro
 func (ev MarkerUnits) MarshalJSON() ([]byte, error)  { return kit.EnumMarshalJSON(ev) }
 func (ev *MarkerUnits) UnmarshalJSON(b []byte) error { return kit.EnumUnmarshalJSON(ev, b) }
 
-// RenderMarker renders the marker using given vertex postion, angle (in
+// RenderMarker renders the marker using given vertex position, angle (in
 // radians), and stroke width
 func (mrk *Marker) RenderMarker(vertexPos gi.Vec2D, vertexAng, strokeWidth float32) {
 	mrk.VertexPos = vertexPos

--- a/svg/path.go
+++ b/svg/path.go
@@ -137,7 +137,7 @@ const (
 	PcZ
 	// close path
 	Pcz
-	// errror -- invalid command
+	// error -- invalid command
 	PcErr
 )
 

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -16,7 +16,7 @@ import (
 
 // see io.go for IO input / output methods
 
-// SVG is a viewport for containing SVG drawing objects, correponding to the
+// SVG is a viewport for containing SVG drawing objects, corresponding to the
 // svg tag in html -- it provides its own bitmap for drawing into
 type SVG struct {
 	gi.Viewport2D

--- a/svg/viewbox.go
+++ b/svg/viewbox.go
@@ -45,7 +45,7 @@ const (
 type ViewBoxMeetOrSlice int32
 
 const (
-	// Mett means the entire ViewBox is visible within Viewport, and it is
+	// Meet means the entire ViewBox is visible within Viewport, and it is
 	// scaled up as much as possible to meet the align constraints
 	Meet ViewBoxMeetOrSlice = iota
 


### PR DESCRIPTION
This PR fixes a number of spelling errors. Most of them are non-functional (comments, error messages, ...). Notable exceptions are

- some misspelled `json` tags (`jsom` instead of `json`) in `gi/window.go`'s `Window` struct
- a misspelled mime type (`image/jepg` instead of `image/jpeg`) in `oswin/mimedata/mimedata.go`