### PR TITLE
enable event propagation when Window not focused

### DIFF
--- a/gi/window.go
+++ b/gi/window.go
@@ -155,6 +155,7 @@ type Window struct {
 	PopupFocus        ki.Ki             `json:"-" xml:"-" desc:"node to focus on when next popup is activated -- use SetNextPopup"`
 	DelPopup          ki.Ki             `json:"-" xml:"-" desc:"this popup will be popped at the end of the current event cycle -- use SetDelPopup"`
 	PopMu             sync.RWMutex      `json:"-" xml:"-" view:"-" desc:"read-write mutex that protects popup updating and access"`
+	BlurEvents        bool              `json:"-" xml:"-" view:"-" desc:"propagate events when the window doesn't have focus"`
 	lastWinMenuUpdate time.Time
 	// below are internal vars used during the event loop
 	delPop        bool
@@ -1542,7 +1543,7 @@ func (w *Window) ProcessEvent(evi oswin.Event) {
 		hasFocus = true // doesn't need focus!
 	}
 
-	if hasFocus && !evi.IsProcessed() {
+	if (hasFocus || w.BlurEvents) && !evi.IsProcessed() {
 		evToPopup := !w.CurPopupIsTooltip() // don't send events to tooltips!
 		w.EventMgr.SendEventSignal(evi, evToPopup)
 		if !w.delPop && et == oswin.MouseMoveEvent && !evi.IsProcessed() {

--- a/gi/window.go
+++ b/gi/window.go
@@ -155,7 +155,6 @@ type Window struct {
 	PopupFocus        ki.Ki             `json:"-" xml:"-" desc:"node to focus on when next popup is activated -- use SetNextPopup"`
 	DelPopup          ki.Ki             `json:"-" xml:"-" desc:"this popup will be popped at the end of the current event cycle -- use SetDelPopup"`
 	PopMu             sync.RWMutex      `json:"-" xml:"-" view:"-" desc:"read-write mutex that protects popup updating and access"`
-	BlurEvents        bool              `json:"-" xml:"-" view:"-" desc:"propagate events when the window doesn't have focus"`
 	lastWinMenuUpdate time.Time
 	// below are internal vars used during the event loop
 	delPop        bool
@@ -1543,7 +1542,7 @@ func (w *Window) ProcessEvent(evi oswin.Event) {
 		hasFocus = true // doesn't need focus!
 	}
 
-	if (hasFocus || w.BlurEvents) && !evi.IsProcessed() {
+	if (hasFocus || !evi.OnWinFocus()) && !evi.IsProcessed() {
 		evToPopup := !w.CurPopupIsTooltip() // don't send events to tooltips!
 		w.EventMgr.SendEventSignal(evi, evToPopup)
 		if !w.delPop && et == oswin.MouseMoveEvent && !evi.IsProcessed() {

--- a/oswin/event.go
+++ b/oswin/event.go
@@ -147,6 +147,9 @@ type Event interface {
 	// OnFocus returns true if the event operates only on focus item (e.g., keyboard events)
 	OnFocus() bool
 
+	// OnWinFocus returns true if the event operates only when the window has focus
+	OnWinFocus() bool
+
 	// Time returns the time at which the event was generated, in UnixNano nanosecond units
 	Time() time.Time
 
@@ -208,6 +211,10 @@ func (ev EventBase) String() string {
 	return fmt.Sprintf("Event at Time: %v", ev.Time())
 }
 
+func (ev EventBase) OnWinFocus() bool {
+	return true
+}
+
 //////////////////////////////////////////////////////////////////////
 // CustomEvent
 
@@ -240,6 +247,10 @@ func (ce CustomEvent) Pos() image.Point {
 
 func (ce CustomEvent) OnFocus() bool {
 	return ce.Focus
+}
+
+func (ce CustomEvent) OnWinFocus() bool {
+	return false
 }
 
 // SendCustomEvent sends a new custom event to given window, with


### PR DESCRIPTION
I'm not sure if this is the right way to handle this. It would be incredibly useful if I could still leverage the `CustomEvent` system for synchronization and UI updates even when the `Window` is not focused. Preventing these `Event`s outright is perhaps overzealous, since the `CustomEvent` system seems like the natural place to synchronize UI updates across threads, and we can't control when the user will remove focus. This is particularly problematic on multi-monitor systems, since even though the `Window` isn't focused, it might still be fully visible. 

I think what you actually want to do is prevent **just the render** when the `Window` is **minimized**, but then apply the render when the `Window` is opened again. This would enable calling methods like `(*TextField).SetText` while the window is out of focus, but avoiding the overhead of a render until necessary. 