### PR TITLE
Don't pass Scene to functions

### DIFF
--- a/filetree/node.go
+++ b/filetree/node.go
@@ -307,7 +307,7 @@ func (fn *Node) SetFileIcon() {
 		if bp.IconDisab != ic {
 			bp.IconDisab = ic
 			bp.Update()
-			fn.SetNeedsRender()
+			fn.SetNeedsRender(true)
 		}
 	}
 }
@@ -379,7 +379,7 @@ func (fn *Node) UpdateNode() error {
 			fn.Info.Vcs, _ = repo.Status(string(fn.FPath))
 		}
 		fn.SetFileIcon()
-		fn.SetNeedsRender()
+		fn.SetNeedsRender(true)
 	}
 	return nil
 }
@@ -448,7 +448,7 @@ func (fn *Node) SortBys(modTime bool) { //gti:add
 // optionally can be sorted by modification time.
 func (fn *Node) SortBy(modTime bool) {
 	fn.FRoot.SetDirSortBy(fn.FPath, modTime)
-	fn.SetNeedsLayout()
+	fn.SetNeedsLayout(true)
 }
 
 // OpenAll opens all directories under this one

--- a/filetree/tree.go
+++ b/filetree/tree.go
@@ -121,7 +121,7 @@ func (ft *Tree) UpdateAll() {
 	// ft.Dirs.DeleteStale()
 	ft.Update()
 	ft.TreeViewChanged(nil)
-	ft.SetNeedsLayout()
+	ft.SetNeedsLayout(true)
 	ft.UpdtMu.Unlock()
 	ft.UpdateEndAsyncLayout(updt)
 }

--- a/filetree/vcs.go
+++ b/filetree/vcs.go
@@ -131,7 +131,7 @@ func (fn *Node) AddToVcs() {
 	err := repo.Add(string(fn.FPath))
 	if err == nil {
 		fn.Info.Vcs = vci.Added
-		fn.SetNeedsRender()
+		fn.SetNeedsRender(true)
 		return
 	}
 	fmt.Println(err)
@@ -157,7 +157,7 @@ func (fn *Node) DeleteFromVcs() {
 	err := repo.DeleteRemote(string(fn.FPath))
 	if fn != nil && err == nil {
 		fn.Info.Vcs = vci.Deleted
-		fn.SetNeedsRender()
+		fn.SetNeedsRender(true)
 		return
 	}
 	fmt.Println(err)
@@ -188,7 +188,7 @@ func (fn *Node) CommitToVcs(message string) (err error) {
 		return err
 	}
 	fn.Info.Vcs = vci.Stored
-	fn.SetNeedsRender()
+	fn.SetNeedsRender(true)
 	return err
 }
 
@@ -223,7 +223,7 @@ func (fn *Node) RevertVcs() (err error) {
 	if fn.Buf != nil {
 		fn.Buf.Revert()
 	}
-	fn.SetNeedsRender()
+	fn.SetNeedsRender(true)
 	return err
 }
 
@@ -473,7 +473,7 @@ func (vv *VersCtrlValue) UpdateWidget() {
 	bt.SetTextUpdate(txt)
 }
 
-func (vv *VersCtrlValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *VersCtrlValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -481,7 +481,7 @@ func (vv *VersCtrlValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.Widget = w
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(bt, nil)

--- a/gi/button.go
+++ b/gi/button.go
@@ -260,7 +260,7 @@ func (bt *Button) SetKey(kf keyfun.Funs) *Button {
 // This is used for more efficient large-scale updating in views.
 func (bt *Button) SetTextUpdate(text string) *Button {
 	bt.Text = text
-	bt.ConfigWidget(bt.Sc)
+	bt.ConfigWidget()
 	lb := bt.LabelWidget()
 	if lb != nil {
 		lb.SetTextUpdate(text)
@@ -274,7 +274,7 @@ func (bt *Button) SetTextUpdate(text string) *Button {
 // This is used for more efficient large-scale updating in views.
 func (bt *Button) SetIconUpdate(icon icons.Icon) *Button {
 	bt.Icon = icon
-	bt.ConfigWidget(bt.Sc)
+	bt.ConfigWidget()
 	ic := bt.IconWidget()
 	if ic != nil {
 		ic.SetIcon(icon)

--- a/gi/button.go
+++ b/gi/button.go
@@ -446,11 +446,11 @@ func (bt *Button) HandleButtonEvents() {
 	bt.HandleClickOnEnterSpace()
 }
 
-func (bt *Button) ConfigWidget(sc *Scene) {
-	bt.ConfigParts(sc)
+func (bt *Button) ConfigWidget() {
+	bt.ConfigParts()
 }
 
-func (bt *Button) ConfigParts(sc *Scene) {
+func (bt *Button) ConfigParts() {
 	parts := bt.NewParts()
 	// we check if the icons are unset, not if they are nil, so
 	// that people can manually set it to [icons.None]
@@ -487,7 +487,7 @@ func (bt *Button) ConfigParts(sc *Scene) {
 	if mods {
 		parts.Update()
 		parts.UpdateEnd(updt)
-		bt.SetNeedsLayoutUpdate(sc, updt)
+		bt.SetNeedsLayout(updt)
 	}
 }
 
@@ -521,7 +521,7 @@ func (bt *Button) ConfigPartsSetIconLabel(icnm icons.Icon, txt string, icIdx, lb
 		lbl := bt.Parts.Child(lbIdx).(*Label)
 		if lbl.Text != txt {
 			lbl.SetText(txt)
-			lbl.Config(bt.Sc) // this is essential
+			lbl.Config() // this is essential
 		}
 	}
 }
@@ -546,17 +546,17 @@ func (bt *Button) ConfigPartsAddShortcut(config *ki.Config) int {
 	return scIdx
 }
 
-func (bt *Button) RenderButton(sc *Scene) {
-	rs, _, st := bt.RenderLock(sc)
-	bt.RenderStdBox(sc, st)
+func (bt *Button) RenderButton() {
+	rs, _, st := bt.RenderLock()
+	bt.RenderStdBox(st)
 	bt.RenderUnlock(rs)
 }
 
-func (bt *Button) Render(sc *Scene) {
-	if bt.PushBounds(sc) {
-		bt.RenderButton(sc)
-		bt.RenderParts(sc)
-		bt.PopBounds(sc)
+func (bt *Button) Render() {
+	if bt.PushBounds() {
+		bt.RenderButton()
+		bt.RenderParts()
+		bt.PopBounds()
 	}
 }
 

--- a/gi/chooser.go
+++ b/gi/chooser.go
@@ -214,11 +214,11 @@ func (ch *Chooser) ChooserStyles() {
 	})
 }
 
-func (ch *Chooser) ConfigWidget(sc *Scene) {
-	ch.ConfigParts(sc)
+func (ch *Chooser) ConfigWidget() {
+	ch.ConfigParts()
 }
 
-func (ch *Chooser) ConfigParts(sc *Scene) {
+func (ch *Chooser) ConfigParts() {
 	parts := ch.NewParts()
 	config := ki.Config{}
 
@@ -253,12 +253,12 @@ func (ch *Chooser) ConfigParts(sc *Scene) {
 	if ch.Editable {
 		tx := ch.Parts.Child(txIdx).(*TextField)
 		tx.SetText(ch.CurLabel)
-		tx.Config(ch.Sc) // this is essential
+		tx.Config() // this is essential
 		tx.SetCompleter(tx, ch.CompleteMatch, ch.CompleteEdit)
 	} else {
 		lbl := ch.Parts.Child(lbIdx).(*Label)
 		lbl.SetText(ch.CurLabel)
-		lbl.Config(ch.Sc) // this is essential
+		lbl.Config() // this is essential
 	}
 	{ // indicator
 		ic := ch.Parts.Child(indIdx).(*Icon)
@@ -267,7 +267,7 @@ func (ch *Chooser) ConfigParts(sc *Scene) {
 	if mods {
 		parts.Update()
 		parts.UpdateEnd(updt)
-		ch.SetNeedsLayoutUpdate(sc, updt)
+		ch.SetNeedsLayout(updt)
 	}
 }
 
@@ -762,17 +762,17 @@ func (ch *Chooser) CompleteEdit(data any, text string, cursorPos int, completion
 	}
 }
 
-func (ch *Chooser) RenderChooser(sc *Scene) {
-	rs, _, st := ch.RenderLock(sc)
-	ch.RenderStdBox(sc, st)
+func (ch *Chooser) RenderChooser() {
+	rs, _, st := ch.RenderLock()
+	ch.RenderStdBox(st)
 	ch.RenderUnlock(rs)
 }
 
-func (ch *Chooser) Render(sc *Scene) {
-	if ch.PushBounds(sc) {
-		ch.RenderChooser(sc)
-		ch.RenderParts(sc)
-		ch.RenderChildren(sc)
-		ch.PopBounds(sc)
+func (ch *Chooser) Render() {
+	if ch.PushBounds() {
+		ch.RenderChooser()
+		ch.RenderParts()
+		ch.RenderChildren()
+		ch.PopBounds()
 	}
 }

--- a/gi/events.go
+++ b/gi/events.go
@@ -167,7 +167,7 @@ func (wb *WidgetBase) HandleEvent(ev events.Event) {
 		return
 	}
 	if s.State != state {
-		wb.ApplyStyleUpdate(wb.Sc)
+		wb.ApplyStyleUpdate()
 		// wb.Transition(&s.StateLayer, s.State.StateLayer(), 500*time.Millisecond, LinearTransition)
 	}
 }

--- a/gi/flags.go
+++ b/gi/flags.go
@@ -72,8 +72,8 @@ func (wb *WidgetBase) SetAbilities(on bool, able ...enums.BitFlag) *WidgetBase {
 // and calls ApplyStyleTree to apply any style changes.
 func (wb *WidgetBase) SetSelected(sel bool) {
 	wb.SetStateWidget(sel, states.Selected)
-	wb.ApplyStyleTree(wb.Sc)
-	wb.SetNeedsRender()
+	wb.ApplyStyleTree()
+	wb.SetNeedsRender(true)
 }
 
 // SetSelectedAction sets the Selected state flag
@@ -102,7 +102,7 @@ func (wb *WidgetBase) SetEnabled(enabled bool) *WidgetBase {
 // SetEnabledUpdt sets the Disabled flag
 func (wb *WidgetBase) SetEnabledUpdt(enabled bool) *WidgetBase {
 	wb.SetState(!enabled, states.Disabled)
-	wb.ApplyStyleUpdate(wb.Sc)
+	wb.ApplyStyleUpdate()
 	return wb
 }
 

--- a/gi/frame.go
+++ b/gi/frame.go
@@ -60,17 +60,17 @@ const (
 )
 
 // FrameStdRender does the standard rendering of the frame itself
-func (fr *Frame) FrameStdRender(sc *Scene) {
-	rs, _, st := fr.RenderLock(sc)
+func (fr *Frame) FrameStdRender() {
+	rs, _, st := fr.RenderLock()
 	defer fr.RenderUnlock(rs)
 
-	fr.RenderStdBox(sc, st)
+	fr.RenderStdBox(st)
 	//	if fr.Lay == LayoutGrid && fr.Stripes != NoStripes && Prefs.Params.ZebraStripeWeight != 0 {
 	//		fr.RenderStripes(sc)
 	//	}
 }
 
-func (fr *Frame) RenderStripes(sc *Scene) {
+func (fr *Frame) RenderStripes() {
 	/*
 		st := &fr.Styles
 		rs := &sc.RenderState
@@ -120,11 +120,11 @@ func (fr *Frame) RenderStripes(sc *Scene) {
 	*/
 }
 
-func (fr *Frame) Render(sc *Scene) {
-	if fr.PushBounds(sc) {
-		fr.FrameStdRender(sc)
-		fr.RenderChildren(sc)
-		fr.RenderScrolls(sc)
-		fr.PopBounds(sc)
+func (fr *Frame) Render() {
+	if fr.PushBounds() {
+		fr.FrameStdRender()
+		fr.RenderChildren()
+		fr.RenderScrolls()
+		fr.PopBounds()
 	}
 }

--- a/gi/icon.go
+++ b/gi/icon.go
@@ -71,7 +71,7 @@ func (ic *Icon) SetIcon(icon icons.Icon) *Icon {
 func (ic *Icon) SetIconTry(icon icons.Icon) (bool, error) {
 	if icon.IsNil() {
 		ic.SVG.DeleteAll()
-		ic.Config(ic.Sc)
+		ic.Config()
 		return false, nil
 	}
 	if ic.SVG.Root.HasChildren() && ic.IconName == icon {
@@ -81,7 +81,7 @@ func (ic *Icon) SetIconTry(icon icons.Icon) (bool, error) {
 	ic.SVG.Config(2, 2)
 	err := ic.SVG.OpenFS(icons.Icons, fnm)
 	if err != nil {
-		ic.Config(ic.Sc)
+		ic.Config()
 		return false, err
 	}
 	ic.IconName = icon
@@ -89,7 +89,7 @@ func (ic *Icon) SetIconTry(icon icons.Icon) (bool, error) {
 
 }
 
-func (ic *Icon) DrawIntoScene(sc *Scene) {
+func (ic *Icon) DrawIntoScene() {
 	if ic.SVG.Pixels == nil {
 		return
 	}
@@ -106,11 +106,11 @@ func (ic *Icon) DrawIntoScene(sc *Scene) {
 		}
 		r = nr
 	}
-	draw.Draw(sc.Pixels, r, ic.SVG.Pixels, sp, draw.Over)
+	draw.Draw(ic.Sc.Pixels, r, ic.SVG.Pixels, sp, draw.Over)
 }
 
 // RenderSVG renders the SVG to Pixels if needs update
-func (ic *Icon) RenderSVG(sc *Scene) {
+func (ic *Icon) RenderSVG() {
 	rc := ic.Sc.RenderCtx()
 	sv := &ic.SVG
 	if !rc.HasFlag(RenderRebuild) && sv.Pixels != nil { // if rebuilding rebuild..
@@ -138,11 +138,11 @@ func (ic *Icon) RenderSVG(sc *Scene) {
 	// fmt.Println("re-rendered icon:", sv.Name, "size:", sz)
 }
 
-func (ic *Icon) Render(sc *Scene) {
-	ic.RenderSVG(sc)
-	if ic.PushBounds(sc) {
-		ic.RenderChildren(sc)
-		ic.DrawIntoScene(sc)
-		ic.PopBounds(sc)
+func (ic *Icon) Render() {
+	ic.RenderSVG()
+	if ic.PushBounds() {
+		ic.RenderChildren()
+		ic.DrawIntoScene()
+		ic.PopBounds()
 	}
 }

--- a/gi/image.go
+++ b/gi/image.go
@@ -145,7 +145,7 @@ func (im *Image) GrabRenderFrom(wi Widget) {
 	}
 }
 
-func (im *Image) DrawIntoScene(sc *Scene) {
+func (im *Image) DrawIntoScene() {
 	if im.Pixels == nil {
 		return
 	}
@@ -162,14 +162,14 @@ func (im *Image) DrawIntoScene(sc *Scene) {
 		}
 		r = nr
 	}
-	draw.Draw(sc.Pixels, r, im.Pixels, sp, draw.Over)
+	draw.Draw(im.Sc.Pixels, r, im.Pixels, sp, draw.Over)
 }
 
-func (im *Image) Render(sc *Scene) {
-	if im.PushBounds(sc) {
-		im.RenderChildren(sc)
-		im.DrawIntoScene(im.Sc)
-		im.PopBounds(sc)
+func (im *Image) Render() {
+	if im.PushBounds() {
+		im.RenderChildren()
+		im.DrawIntoScene()
+		im.PopBounds()
 	}
 }
 

--- a/gi/image.go
+++ b/gi/image.go
@@ -279,7 +279,7 @@ func ImageResizeMax(img image.Image, maxSz int) image.Image {
 //////////////////////////////////////////////////////////////////////////////////
 //  Props
 
-// TODO: move this to comment directives
+// TODO(kai): move this to new system
 
 var ImageProps = ki.Props{
 	"Toolbar": ki.PropSlice{

--- a/gi/label.go
+++ b/gi/label.go
@@ -209,7 +209,7 @@ func (lb *Label) LabelStyles() {
 func (lb *Label) SetTextUpdate(text string) *Label {
 	updt := lb.UpdateStart()
 	lb.Text = text
-	lb.ConfigLabel(lb.Sc)
+	lb.ConfigLabel()
 	lb.UpdateEndRender(updt)
 	return lb
 }
@@ -313,8 +313,8 @@ func (lb *Label) HandleLabelKeys() {
 	})
 }
 
-func (lb *Label) ConfigWidget(sc *Scene) {
-	lb.ConfigLabel(sc)
+func (lb *Label) ConfigWidget() {
+	lb.ConfigLabel()
 }
 
 // todo: ideally it would be possible to only call SetHTML once during config
@@ -324,13 +324,13 @@ func (lb *Label) ConfigWidget(sc *Scene) {
 
 // ConfigLabel does the HTML and Layout in TextRender for label text,
 // using actual content size to constrain layout.
-func (lb *Label) ConfigLabel(sc *Scene) {
-	lb.ConfigLabelSize(sc, lb.Geom.Size.Actual.Content)
+func (lb *Label) ConfigLabel() {
+	lb.ConfigLabelSize(lb.Geom.Size.Actual.Content)
 }
 
 // ConfigLabel does the HTML and Layout in TextRender for label text,
 // using given size to constrain layout.
-func (lb *Label) ConfigLabelSize(sc *Scene, sz mat32.Vec2) {
+func (lb *Label) ConfigLabelSize(sz mat32.Vec2) {
 	lb.StyMu.RLock()
 	defer lb.StyMu.RUnlock()
 
@@ -346,7 +346,7 @@ func (lb *Label) ConfigLabelSize(sc *Scene, sz mat32.Vec2) {
 // In this case, alignment factors are turned off,
 // because they otherwise can absorb much more space, which should
 // instead be controlled by the base Align X,Y factors.
-func (lb *Label) ConfigLabelAlloc(sc *Scene, sz mat32.Vec2) mat32.Vec2 {
+func (lb *Label) ConfigLabelAlloc(sz mat32.Vec2) mat32.Vec2 {
 	lb.StyMu.RLock()
 	defer lb.StyMu.RUnlock()
 
@@ -367,7 +367,7 @@ func (lb *Label) ConfigLabelAlloc(sc *Scene, sz mat32.Vec2) mat32.Vec2 {
 // for word wrap case, where the sizing actually matters.
 // this is based on the existing styled Actual.Content aspect ratio and
 // very rough estimate of total rendered size.
-func (lb *Label) SizeUpWrapSize(sc *Scene) mat32.Vec2 {
+func (lb *Label) SizeUpWrapSize() mat32.Vec2 {
 	csz := lb.Geom.Size.Actual.Content
 	chars := float32(len(lb.Text))
 	fht := float32(16)
@@ -397,13 +397,13 @@ func (lb *Label) SizeUpWrapSize(sc *Scene) mat32.Vec2 {
 	return sz
 }
 
-func (lb *Label) SizeUp(sc *Scene) {
-	lb.WidgetBase.SizeUp(sc) // sets Actual size based on styles
+func (lb *Label) SizeUp() {
+	lb.WidgetBase.SizeUp() // sets Actual size based on styles
 	sz := &lb.Geom.Size
 	if lb.Styles.Text.HasWordWrap() {
-		lb.ConfigLabelSize(sc, lb.SizeUpWrapSize(sc))
+		lb.ConfigLabelSize(lb.SizeUpWrapSize())
 	} else {
-		lb.ConfigLabelSize(sc, sz.Actual.Content)
+		lb.ConfigLabelSize(sz.Actual.Content)
 	}
 	rsz := lb.TextRender.Size.Ceil()
 	sz.FitSizeMax(&sz.Actual.Content, rsz)
@@ -413,12 +413,12 @@ func (lb *Label) SizeUp(sc *Scene) {
 	}
 }
 
-func (lb *Label) SizeDown(sc *Scene, iter int) bool {
+func (lb *Label) SizeDown(iter int) bool {
 	if !lb.Styles.Text.HasWordWrap() || iter > 1 {
 		return false
 	}
 	sz := &lb.Geom.Size
-	rsz := lb.ConfigLabelAlloc(sc, sz.Alloc.Content) // use allocation
+	rsz := lb.ConfigLabelAlloc(sz.Alloc.Content) // use allocation
 	prevContent := sz.Actual.Content
 	// start over so we don't reflect hysteresis of prior guess
 	sz.SetInitContentMin(lb.Styles.Min.Dots().Ceil())
@@ -433,26 +433,26 @@ func (lb *Label) SizeDown(sc *Scene, iter int) bool {
 	return chg
 }
 
-// func (lb *Label) SizeFinal(sc *Scene) {
+// func (lb *Label) SizeFinal() {
 // 	sz := &lb.Geom.Size
 // 	sz.Internal = sz.Actual.Content // keep it before we grow
-// 	// lb.GrowToAlloc(sc)     // we already grew as much as we could..
-// 	lb.StyleSizeUpdate(sc) // now that sizes are stable, ensure styling based on size is updated
-// 	lb.SizeFinalParts(sc)
+// 	// lb.GrowToAlloc()     // we already grew as much as we could..
+// 	lb.StyleSizeUpdate() // now that sizes are stable, ensure styling based on size is updated
+// 	lb.SizeFinalParts()
 // 	sz.SetTotalFromContent(&sz.Actual)
 // }
 
-func (lb *Label) RenderLabel(sc *Scene) {
-	rs, _, st := lb.RenderLock(sc)
+func (lb *Label) RenderLabel() {
+	rs, _, st := lb.RenderLock()
 	defer lb.RenderUnlock(rs)
-	lb.RenderStdBox(sc, st)
+	lb.RenderStdBox(st)
 	lb.TextRender.Render(rs, lb.Geom.Pos.Content)
 }
 
-func (lb *Label) Render(sc *Scene) {
-	if lb.PushBounds(sc) {
-		lb.RenderLabel(sc)
-		lb.RenderChildren(sc)
-		lb.PopBounds(sc)
+func (lb *Label) Render() {
+	if lb.PushBounds() {
+		lb.RenderLabel()
+		lb.RenderChildren()
+		lb.PopBounds()
 	}
 }

--- a/gi/layout.go
+++ b/gi/layout.go
@@ -166,25 +166,25 @@ func (ly *Layout) DeleteScroll(d mat32.Dims) {
 	ly.Scrolls[d] = nil
 }
 
-func (ly *Layout) RenderChildren(sc *Scene) {
+func (ly *Layout) RenderChildren() {
 	if ly.Styles.Display == styles.Stacked {
 		kwi, _ := ly.StackTopWidget()
 		if kwi != nil {
-			kwi.Render(sc)
+			kwi.Render()
 		}
 		return
 	}
 	ly.WidgetKidsIter(func(i int, kwi Widget, kwb *WidgetBase) bool {
-		kwi.Render(sc)
+		kwi.Render()
 		return ki.Continue
 	})
 }
 
-func (ly *Layout) Render(sc *Scene) {
-	if ly.PushBounds(sc) {
-		ly.RenderChildren(sc)
-		ly.PopBounds(sc)
-		ly.RenderScrolls(sc)
+func (ly *Layout) Render() {
+	if ly.PushBounds() {
+		ly.RenderChildren()
+		ly.PopBounds()
+		ly.RenderScrolls()
 	}
 }
 

--- a/gi/menubar.go
+++ b/gi/menubar.go
@@ -75,21 +75,21 @@ func (mb *MenuBar) ShowMenuBar() bool {
 	return true
 }
 
-// func (mb *MenuBar) GetSize(sc *Scene, iter int) {
+// func (mb *MenuBar) GetSize(iter int) {
 // 	if !mb.ShowMenuBar() {
 // 		return
 // 	}
-// 	mb.Layout.GetSize(sc, iter)
+// 	mb.Layout.GetSize(iter)
 // }
 //
-// func (mb *MenuBar) DoLayout(sc *Scene, parBBox image.Rectangle, iter int) bool {
+// func (mb *MenuBar) DoLayout(parBBox image.Rectangle, iter int) bool {
 // 	if !mb.ShowMenuBar() {
 // 		return false
 // 	}
-// 	return mb.Layout.DoLayout(sc, parBBox, iter)
+// 	return mb.Layout.DoLayout(parBBox, iter)
 // }
 
-func (mb *MenuBar) Render(sc *Scene) {
+func (mb *MenuBar) Render() {
 	if !mb.ShowMenuBar() {
 		return
 	}

--- a/gi/menubar.go
+++ b/gi/menubar.go
@@ -55,8 +55,8 @@ func (mb *MenuBar) MenuBarStyles() {
 }
 
 // MenuBarStdRender does the standard rendering of the bar
-func (mb *MenuBar) MenuBarStdRender(sc *Scene) {
-	rs, pc, st := mb.RenderLock(sc)
+func (mb *MenuBar) MenuBarStdRender() {
+	rs, pc, st := mb.RenderLock()
 	pos := mb.Geom.Pos.Total
 	sz := mb.Geom.Size.Actual.Total
 	pc.FillBox(rs, pos, sz, &st.BackgroundColor)
@@ -93,11 +93,11 @@ func (mb *MenuBar) Render(sc *Scene) {
 	if !mb.ShowMenuBar() {
 		return
 	}
-	if mb.PushBounds(sc) {
-		mb.MenuBarStdRender(sc)
-		mb.RenderScrolls(sc)
-		mb.RenderChildren(sc)
-		mb.PopBounds(sc)
+	if mb.PushBounds() {
+		mb.MenuBarStdRender()
+		mb.RenderScrolls()
+		mb.RenderChildren()
+		mb.PopBounds()
 	}
 }
 

--- a/gi/render.go
+++ b/gi/render.go
@@ -352,7 +352,7 @@ func (sc *Scene) LayoutScene() {
 	if LayoutTrace {
 		fmt.Println("\n############################\nLayoutScene SizeUp start:", sc)
 	}
-	sc.SizeUp(sc)
+	sc.SizeUp()
 	sz := &sc.Geom.Size
 	sz.Alloc.Total.SetPoint(sc.SceneGeom.Size)
 	sz.SetContentFromTotal(&sz.Alloc)
@@ -362,7 +362,7 @@ func (sc *Scene) LayoutScene() {
 	}
 	maxIter := 3
 	for iter := 0; iter < maxIter; iter++ { // 3  > 2; 4 same as 3
-		redo := sc.SizeDown(sc, iter)
+		redo := sc.SizeDown(iter)
 		if redo && iter < maxIter-1 {
 			if LayoutTrace {
 				fmt.Println("\n############################\nSizeDown redo:", sc, "iter:", iter+1)
@@ -374,22 +374,22 @@ func (sc *Scene) LayoutScene() {
 	if LayoutTrace {
 		fmt.Println("\n############################\nSizeFinal start:", sc)
 	}
-	sc.SizeFinal(sc)
+	sc.SizeFinal()
 	if LayoutTrace {
 		fmt.Println("\n############################\nPosition start:", sc)
 	}
-	sc.Position(sc)
+	sc.Position()
 	if LayoutTrace {
 		fmt.Println("\n############################\nScenePos start:", sc)
 	}
-	sc.ScenePos(sc)
+	sc.ScenePos()
 }
 
 // LayoutRenderScene does a layout and render of the tree:
 // GetSize, DoLayout, Render.  Needed after Config.
 func (sc *Scene) LayoutRenderScene() {
 	sc.LayoutScene()
-	sc.Render(sc)
+	sc.Render()
 }
 
 // DoNeedsRender calls Render on tree from me for nodes
@@ -598,9 +598,9 @@ func (wb *WidgetBase) PopBounds() {
 		pcfc := pc.FillStyle.Color
 		pcop := pc.FillStyle.Opacity
 		pc.StrokeStyle.Width.Dot(1)
-		pc.StrokeStyle.SetColor(hct.New(sc.RenderBBoxHue, 100, 50).AsRGBA())
+		pc.StrokeStyle.SetColor(hct.New(wb.Sc.RenderBBoxHue, 100, 50).AsRGBA())
 		pc.FillStyle.SetColor(nil)
-		if sc.SelectedWidget != nil && sc.SelectedWidget.This() == wb.This() {
+		if wb.Sc.SelectedWidget != nil && wb.Sc.SelectedWidget.This() == wb.This() {
 			fc := pc.StrokeStyle.Color.Solid
 			pc.FillStyle.SetColor(fc)
 			pc.FillStyle.Opacity = 0.2
@@ -809,7 +809,7 @@ func (sc *Scene) BenchmarkFullRender() {
 	n := 50
 	for i := 0; i < n; i++ {
 		sc.LayoutScene()
-		sc.Render(sc)
+		sc.Render()
 	}
 	td := time.Since(ts)
 	fmt.Printf("Time for %v Re-Renders: %12.2f s\n", n, float64(td)/float64(time.Second))
@@ -827,7 +827,7 @@ func (sc *Scene) BenchmarkReRender() {
 	ts := time.Now()
 	n := 50
 	for i := 0; i < n; i++ {
-		sc.Render(sc)
+		sc.Render()
 	}
 	td := time.Since(ts)
 	fmt.Printf("Time for %v Re-Renders: %12.2f s\n", n, float64(td)/float64(time.Second))

--- a/gi/scroll.go
+++ b/gi/scroll.go
@@ -47,16 +47,16 @@ func (ly *Layout) ScrollGeom(d mat32.Dims) (pos, sz mat32.Vec2) {
 // the sizing and need for scrollbars has been established.
 // The final position of the scrollbars is set during ScenePos in
 // PositionScrolls.  Scrolls are kept around in general.
-func (ly *Layout) ConfigScrolls(sc *Scene) {
+func (ly *Layout) ConfigScrolls() {
 	for d := mat32.X; d <= mat32.Y; d++ {
 		if ly.HasScroll[d] {
-			ly.ConfigScroll(sc, d)
+			ly.ConfigScroll(d)
 		}
 	}
 }
 
 // ConfigScroll configures scroll for given dimension
-func (ly *Layout) ConfigScroll(sc *Scene, d mat32.Dims) {
+func (ly *Layout) ConfigScroll(d mat32.Dims) {
 	if ly.Scrolls[d] != nil {
 		return
 	}
@@ -89,14 +89,14 @@ func (ly *Layout) ConfigScroll(sc *Scene, d mat32.Dims) {
 		e.SetHandled()
 		// fmt.Println("change event")
 		updt := ly.UpdateStart()
-		ly.This().(Widget).ScenePos(ly.Sc) // gets pos from scrolls, positions scrollbars
+		ly.This().(Widget).ScenePos() // gets pos from scrolls, positions scrollbars
 		ly.UpdateEndRender(updt)
 	})
 	sb.Update()
 }
 
 // GetScrollPosition sets our layout Scroll position from scrollbars
-func (ly *Layout) GetScrollPosition(sc *Scene) {
+func (ly *Layout) GetScrollPosition() {
 	for d := mat32.X; d <= mat32.Y; d++ {
 		ly.Geom.Scroll.SetDim(d, 0)
 		if ly.HasScroll[d] {
@@ -111,15 +111,15 @@ func (ly *Layout) GetScrollPosition(sc *Scene) {
 }
 
 // PositionScrolls arranges scrollbars
-func (ly *Layout) PositionScrolls(sc *Scene) {
+func (ly *Layout) PositionScrolls() {
 	for d := mat32.X; d <= mat32.Y; d++ {
 		if ly.HasScroll[d] {
-			ly.PositionScroll(sc, d)
+			ly.PositionScroll(d)
 		}
 	}
 }
 
-func (ly *Layout) PositionScroll(sc *Scene, d mat32.Dims) {
+func (ly *Layout) PositionScroll(d mat32.Dims) {
 	sb := ly.Scrolls[d]
 	sz := &ly.Geom.Size
 	pos, ssz := ly.ScrollGeom(d)
@@ -142,9 +142,9 @@ func (ly *Layout) PositionScroll(sc *Scene, d mat32.Dims) {
 	sb.SetValue(sb.Value) // keep in range
 
 	sb.Update() // applies style
-	sb.SizeUp(sc)
+	sb.SizeUp()
 	sb.Geom.Size.Alloc = ly.Geom.Size.Actual
-	sb.SizeDown(sc, 0)
+	sb.SizeDown(0)
 
 	sb.Geom.Pos.Total = pos
 	sb.SetContentPosFromPos()
@@ -154,10 +154,10 @@ func (ly *Layout) PositionScroll(sc *Scene, d mat32.Dims) {
 }
 
 // RenderScrolls draws the scrollbars
-func (ly *Layout) RenderScrolls(sc *Scene) {
+func (ly *Layout) RenderScrolls() {
 	for d := mat32.X; d <= mat32.Y; d++ {
 		if ly.HasScroll[d] {
-			ly.Scrolls[d].Render(sc)
+			ly.Scrolls[d].Render()
 		}
 	}
 }
@@ -176,7 +176,7 @@ func (ly *Layout) ScrollActionDelta(d mat32.Dims, delta float32) {
 		sb := ly.Scrolls[d]
 		nval := sb.Value + delta
 		sb.SetValueAction(nval)
-		ly.SetNeedsRender() // only render needed -- scroll updates pos
+		ly.SetNeedsRender(true) // only render needed -- scroll updates pos
 	}
 }
 
@@ -186,7 +186,7 @@ func (ly *Layout) ScrollActionPos(d mat32.Dims, pos float32) {
 	if ly.HasScroll[d] {
 		sb := ly.Scrolls[d]
 		sb.SetValueAction(pos)
-		ly.SetNeedsRender()
+		ly.SetNeedsRender(true)
 	}
 }
 
@@ -196,7 +196,7 @@ func (ly *Layout) ScrollToPos(d mat32.Dims, pos float32) {
 	if ly.HasScroll[d] {
 		sb := ly.Scrolls[d]
 		sb.SetValueAction(pos)
-		ly.SetNeedsRender()
+		ly.SetNeedsRender(true)
 	}
 }
 
@@ -389,7 +389,7 @@ func (ly *Layout) ScrollToBox(box image.Rectangle) bool {
 		did = ly.ScrollToBoxDim(mat32.X, box.Min.X, box.Max.X)
 	}
 	if did {
-		ly.SetNeedsRender()
+		ly.SetNeedsRender(true)
 	}
 	return did
 }

--- a/gi/separator.go
+++ b/gi/separator.go
@@ -53,8 +53,8 @@ func (sp *Separator) CopyFieldsFrom(frm any) {
 	sp.Horiz = fr.Horiz
 }
 
-func (sp *Separator) RenderSeparator(sc *Scene) {
-	rs, pc, st := sp.RenderLock(sc)
+func (sp *Separator) RenderSeparator() {
+	rs, pc, st := sp.RenderLock()
 	defer sp.RenderUnlock(rs)
 
 	pos := sp.Geom.Pos.Total.Add(st.TotalMargin().Pos())
@@ -74,10 +74,10 @@ func (sp *Separator) RenderSeparator(sc *Scene) {
 	pc.FillStrokeClear(rs)
 }
 
-func (sp *Separator) Render(sc *Scene) {
-	if sp.PushBounds(sc) {
-		sp.RenderSeparator(sc)
-		sp.RenderChildren(sc)
-		sp.PopBounds(sc)
+func (sp *Separator) Render() {
+	if sp.PushBounds() {
+		sp.RenderSeparator()
+		sp.RenderChildren()
+		sp.PopBounds()
 	}
 }

--- a/gi/slider.go
+++ b/gi/slider.go
@@ -478,15 +478,15 @@ func (sr *Slider) HandleSliderEvents() {
 ///////////////////////////////////////////////////////////
 // 	Config
 
-func (sr *Slider) ConfigWidget(sc *Scene) {
-	sr.ConfigSlider(sc)
+func (sr *Slider) ConfigWidget() {
+	sr.ConfigSlider()
 }
 
-func (sr *Slider) ConfigSlider(sc *Scene) {
-	sr.ConfigParts(sc)
+func (sr *Slider) ConfigSlider() {
+	sr.ConfigParts()
 }
 
-func (sr *Slider) ConfigParts(sc *Scene) {
+func (sr *Slider) ConfigParts() {
 	if !sr.Icon.IsValid() {
 		if sr.Parts != nil {
 			sr.DeleteParts()
@@ -502,15 +502,15 @@ func (sr *Slider) ConfigParts(sc *Scene) {
 	ic.Update()
 }
 
-func (sr *Slider) Render(sc *Scene) {
-	if sr.PushBounds(sc) {
-		sr.RenderSlider(sc)
-		sr.PopBounds(sc)
+func (sr *Slider) Render() {
+	if sr.PushBounds() {
+		sr.RenderSlider()
+		sr.PopBounds()
 	}
 }
 
-func (sr *Slider) RenderSlider(sc *Scene) {
-	rs, pc, st := sr.RenderLock(sc)
+func (sr *Slider) RenderSlider() {
+	rs, pc, st := sr.RenderLock()
 
 	sr.SetPosFromValue(sr.Value)
 
@@ -519,7 +519,7 @@ func (sr *Slider) RenderSlider(sc *Scene) {
 		// pc.StrokeStyle.SetColor(&st.Border.Color)
 		// pc.StrokeStyle.Width = st.Border.Width
 
-		sr.RenderStdBox(sc, st)
+		sr.RenderStdBox(st)
 
 		bg := st.StateBackgroundColor(st.BackgroundColor)
 		if bg.IsNil() {
@@ -528,7 +528,7 @@ func (sr *Slider) RenderSlider(sc *Scene) {
 		sz := sr.Geom.Size.Actual.Content
 		pos := sr.Geom.Pos.Content
 		pc.FillStyle.SetFullColor(&bg)
-		sr.RenderBoxImpl(sc, pos, sz, st.Border) // surround box
+		sr.RenderBoxImpl(pos, sz, st.Border) // surround box
 		if !sr.ValueColor.IsNil() {
 			thsz := sr.SlideThumbSize()
 			osz := sr.ThumbSizeDots().Dim(od)
@@ -541,7 +541,7 @@ func (sr *Slider) RenderSlider(sc *Scene) {
 			tsz.SetDim(od, osz)
 			tpos.SetAddDim(od, 0.5*(osz-origsz))
 			pc.FillStyle.SetFullColor(&sr.ValueColor)
-			sr.RenderBoxImpl(sc, tpos, tsz, st.Border)
+			sr.RenderBoxImpl(tpos, tsz, st.Border)
 		}
 		sr.RenderUnlock(rs)
 	} else {
@@ -552,7 +552,7 @@ func (sr *Slider) RenderSlider(sc *Scene) {
 		pos := sr.Geom.Pos.Content
 		bg, _ := sr.ParentBackgroundColor()
 		pc.FillStyle.SetFullColor(&bg)
-		sr.RenderBoxImpl(sc, pos, sz, st.Border)
+		sr.RenderBoxImpl(pos, sz, st.Border)
 
 		// need to apply state layer
 		ebg := st.StateBackgroundColor(st.BackgroundColor)
@@ -566,12 +566,12 @@ func (sr *Slider) RenderSlider(sc *Scene) {
 		bsz.SetDim(od, trsz)
 		bpos := pos
 		bpos.SetAddDim(od, .5*(sz.Dim(od)-trsz))
-		sr.RenderBoxImpl(sc, bpos, bsz, st.Border) // track
+		sr.RenderBoxImpl(bpos, bsz, st.Border) // track
 
 		if !sr.ValueColor.IsNil() {
 			bsz.SetDim(sr.Dim, sr.Pos)
 			pc.FillStyle.SetFullColor(&sr.ValueColor)
-			sr.RenderBoxImpl(sc, bpos, bsz, st.Border)
+			sr.RenderBoxImpl(bpos, bsz, st.Border)
 		}
 
 		thsz := sr.ThumbSizeDots()
@@ -587,19 +587,19 @@ func (sr *Slider) RenderSlider(sc *Scene) {
 			tpos.SetSub(icsz.MulScalar(.5))
 			ic.Geom.Pos.Total = tpos
 			ic.SetContentPosFromPos()
-			ic.SetBBoxes(sc)
-			sr.Parts.Render(sc)
+			ic.SetBBoxes()
+			sr.Parts.Render()
 		} else {
 			pc.FillStyle.SetFullColor(&sr.ThumbColor)
 			tpos.SetSub(thsz.MulScalar(0.5))
-			sr.RenderBoxImpl(sc, tpos, thsz, st.Border)
+			sr.RenderBoxImpl(tpos, thsz, st.Border)
 			sr.RenderUnlock(rs)
 		}
 	}
 }
 
-func (sr *Slider) ScenePos(sc *Scene) {
-	sr.WidgetBase.ScenePos(sc)
+func (sr *Slider) ScenePos() {
+	sr.WidgetBase.ScenePos()
 	if !sr.StayInView {
 		return
 	}
@@ -609,7 +609,7 @@ func (sr *Slider) ScenePos(sc *Scene) {
 		return
 	}
 	sbw := mat32.Ceil(sr.Styles.ScrollBarWidth.Dots)
-	scmax := mat32.NewVec2FmPoint(sc.Geom.ContentBBox.Max).SubScalar(sbw)
+	scmax := mat32.NewVec2FmPoint(sr.Sc.Geom.ContentBBox.Max).SubScalar(sbw)
 	sr.Geom.Pos.Total.SetMin(scmax)
 	sr.SetContentPosFromPos()
 	sr.SetBBoxesFromAllocs()

--- a/gi/spinner.go
+++ b/gi/spinner.go
@@ -95,9 +95,9 @@ func (sp *Spinner) SetTextToValue() {
 	sp.SetTextUpdate(sp.ValToString(sp.Value))
 }
 
-func (sp *Spinner) SizeUp(sc *Scene) {
+func (sp *Spinner) SizeUp() {
 	sp.SetTextToValue()
-	sp.TextField.SizeUp(sc)
+	sp.TextField.SizeUp()
 }
 
 // SetMin sets the min limits on the value

--- a/gi/splits.go
+++ b/gi/splits.go
@@ -253,12 +253,12 @@ func (sl *Splits) SetSplitAction(idx int, nwval float32) {
 	sl.UpdateEndLayout(updt)
 }
 
-func (sl *Splits) ConfigWidget(sc *Scene) {
+func (sl *Splits) ConfigWidget() {
 	sl.UpdateSplits()
-	sl.ConfigSplitters(sc)
+	sl.ConfigSplitters()
 }
 
-func (sl *Splits) ConfigSplitters(sc *Scene) {
+func (sl *Splits) ConfigSplitters() {
 	parts := sl.NewParts()
 	sz := len(sl.Kids)
 	mods, updt := parts.SetNChildren(sz-1, HandleType, "handle-")
@@ -310,17 +310,17 @@ func (sl *Splits) HandleSplitsEvents() {
 	sl.HandleSplitsKeys()
 }
 
-func (sl *Splits) ApplyStyle(sc *Scene) {
+func (sl *Splits) ApplyStyle() {
 	sl.StyMu.Lock()
 
 	sl.UpdateSplits()
-	sl.ApplyStyleWidget(sc)
+	sl.ApplyStyleWidget()
 	sl.StyMu.Unlock()
 
-	sl.ConfigSplitters(sc)
+	sl.ConfigSplitters()
 }
 
-func (sl *Splits) SizeDownSetAllocs(sc *Scene, iter int) {
+func (sl *Splits) SizeDownSetAllocs(iter int) {
 	sz := &sl.Geom.Size
 	csz := sz.Alloc.Content
 	// fmt.Println(sl, sz.String())
@@ -338,18 +338,18 @@ func (sl *Splits) SizeDownSetAllocs(sc *Scene, iter int) {
 	})
 }
 
-func (sl *Splits) Position(sc *Scene) {
+func (sl *Splits) Position() {
 	if !sl.HasChildren() {
-		sl.Layout.Position(sc)
+		sl.Layout.Position()
 		return
 	}
 	sl.UpdateSplits()
-	sl.ConfigScrolls(sc)
-	sl.PositionSplits(sc)
-	sl.PositionChildren(sc)
+	sl.ConfigScrolls()
+	sl.PositionSplits()
+	sl.PositionChildren()
 }
 
-func (sl *Splits) PositionSplits(sc *Scene) {
+func (sl *Splits) PositionSplits() {
 	if sl.Parts != nil {
 		sl.Parts.Geom.Size = sl.Geom.Size // inherit: allows bbox to include handle
 	}
@@ -390,8 +390,8 @@ func (sl *Splits) PositionSplits(sc *Scene) {
 	})
 }
 
-func (sl *Splits) Render(sc *Scene) {
-	if sl.PushBounds(sc) {
+func (sl *Splits) Render() {
+	if sl.PushBounds() {
 		sl.WidgetKidsIter(func(i int, kwi Widget, kwb *WidgetBase) bool {
 			sp := sl.Splits[i]
 			if sp <= 0.01 {
@@ -399,11 +399,11 @@ func (sl *Splits) Render(sc *Scene) {
 			} else {
 				kwb.SetState(false, states.Invisible)
 			}
-			kwi.Render(sc)
+			kwi.Render()
 			return ki.Continue
 		})
-		sl.RenderParts(sc)
-		sl.PopBounds(sc)
+		sl.RenderParts()
+		sl.PopBounds()
 	}
 }
 

--- a/gi/style.go
+++ b/gi/style.go
@@ -73,17 +73,17 @@ func (wb *WidgetBase) BoxSpace() styles.SideFloats {
 
 // ApplyStyleParts styles the parts.
 // Automatically called by the default ApplyStyleWidget function.
-func (wb *WidgetBase) ApplyStyleParts(sc *Scene) {
+func (wb *WidgetBase) ApplyStyleParts() {
 	if wb.Parts == nil {
 		return
 	}
-	wb.Parts.ApplyStyleTree(sc)
+	wb.Parts.ApplyStyleTree()
 }
 
 // ApplyStyleWidget is the primary styling function for all Widgets.
 // Handles inheritance and runs the Styler functions.
 // Must be called under a StyMu Lock
-func (wb *WidgetBase) ApplyStyleWidget(sc *Scene) {
+func (wb *WidgetBase) ApplyStyleWidget() {
 	if wb.OverrideStyle {
 		return
 	}
@@ -102,9 +102,9 @@ func (wb *WidgetBase) ApplyStyleWidget(sc *Scene) {
 	if wb.Styles.Display == styles.DisplayNone {
 		wb.SetState(true, states.Invisible)
 	}
-	SetUnitContext(&wb.Styles, sc, mat32.Vec2{}, mat32.Vec2{})
-	sc.SetCurrentColor(wb.Styles.Color) // todo: do we need this anymore?
-	wb.ApplyStyleParts(sc)
+	SetUnitContext(&wb.Styles, wb.Sc, mat32.Vec2{}, mat32.Vec2{})
+	wb.Sc.SetCurrentColor(wb.Styles.Color) // todo: do we need this anymore?
+	wb.ApplyStyleParts()
 }
 
 // ResetStyleWidget resets the widget styles and applies the basic
@@ -187,18 +187,18 @@ func (wb *WidgetBase) ApplyStylePrefs() {
 	s.Gap.Y.Val *= spc
 }
 
-func (wb *WidgetBase) ApplyStyleUpdate(sc *Scene) {
+func (wb *WidgetBase) ApplyStyleUpdate() {
 	updt := wb.UpdateStart()
-	wb.ApplyStyleTree(sc)
+	wb.ApplyStyleTree()
 	wb.UpdateEnd(updt)
-	wb.SetNeedsRenderUpdate(sc, updt)
+	wb.SetNeedsRender(updt)
 }
 
-func (wb *WidgetBase) ApplyStyle(sc *Scene) {
+func (wb *WidgetBase) ApplyStyle() {
 	wb.StyMu.Lock() // todo: needed??  maybe not.
 	defer wb.StyMu.Unlock()
 
-	wb.ApplyStyleWidget(sc)
+	wb.ApplyStyleWidget()
 }
 
 // SetUnitContext sets the unit context based on size of scene, element, and parent

--- a/gi/style_test.go
+++ b/gi/style_test.go
@@ -44,8 +44,8 @@ func TestParentBackgroundColor(t *testing.T) {
 	})
 	sc.AssertPixelsOnShow(t, filepath.Join("style", "parent_background_color", "white_hovered_post"), func() {
 		fr.SetState(true, states.Hovered)
-		fr.ApplyStyleTree(sc)
-		fr.SetNeedsRender()
+		fr.ApplyStyleTree()
+		fr.SetNeedsRender(true)
 	})
 
 	sc, fr = make()
@@ -69,7 +69,7 @@ func TestParentBackgroundColor(t *testing.T) {
 	})
 	sc.AssertPixelsOnShow(t, filepath.Join("style", "parent_background_color", "gray_hovered_post"), func() {
 		fr.SetState(true, states.Hovered)
-		fr.ApplyStyleTree(sc)
-		fr.SetNeedsRender()
+		fr.ApplyStyleTree()
+		fr.SetNeedsRender(true)
 	})
 }

--- a/gi/switch.go
+++ b/gi/switch.go
@@ -111,7 +111,7 @@ func (sw *Switch) HandleSwitchEvents() {
 		sw.SetChecked(!sw.StateIs(states.Checked))
 		sw.SendChange(e)
 		if sw.Type == SwitchChip {
-			sw.SetNeedsLayout()
+			sw.SetNeedsLayout(true)
 		}
 	})
 }
@@ -283,11 +283,11 @@ func (sw *Switch) ClearIcons() *Switch {
 	return sw
 }
 
-func (sw *Switch) ConfigWidget(sc *Scene) {
-	sw.ConfigParts(sc)
+func (sw *Switch) ConfigWidget() {
+	sw.ConfigParts()
 }
 
-func (sw *Switch) ConfigParts(sc *Scene) {
+func (sw *Switch) ConfigParts() {
 	parts := sw.NewParts()
 	if sw.IconOn == "" {
 		sw.IconOn = icons.ToggleOn.Fill() // fallback
@@ -325,17 +325,17 @@ func (sw *Switch) ConfigParts(sc *Scene) {
 	if mods {
 		parts.Update()
 		parts.UpdateEnd(updt)
-		sw.SetNeedsLayoutUpdate(sc, updt)
+		sw.SetNeedsLayout(updt)
 	}
 }
 
-func (sw *Switch) RenderSwitch(sc *Scene) {
-	rs, _, st := sw.RenderLock(sc)
-	sw.RenderStdBox(sc, st)
+func (sw *Switch) RenderSwitch() {
+	rs, _, st := sw.RenderLock()
+	sw.RenderStdBox(st)
 	sw.RenderUnlock(rs)
 }
 
-func (sw *Switch) Render(sc *Scene) {
+func (sw *Switch) Render() {
 	sw.SetIconFromState() // make sure we're always up-to-date on render
 	if sw.Parts != nil {
 		ist := sw.Parts.ChildByName("stack", 0)
@@ -343,10 +343,10 @@ func (sw *Switch) Render(sc *Scene) {
 			ist.(*Layout).UpdateStackedVisibility()
 		}
 	}
-	if sw.PushBounds(sc) {
-		sw.RenderSwitch(sc)
-		sw.RenderParts(sc)
-		sw.RenderChildren(sc)
-		sw.PopBounds(sc)
+	if sw.PushBounds() {
+		sw.RenderSwitch()
+		sw.RenderParts()
+		sw.RenderChildren()
+		sw.PopBounds()
 	}
 }

--- a/gi/switches.go
+++ b/gi/switches.go
@@ -259,7 +259,7 @@ func (sw *Switches) ConfigItems() {
 	}
 }
 
-func (sw *Switches) ConfigSwitches(sc *Scene) {
+func (sw *Switches) ConfigSwitches() {
 	if len(sw.Items) == 0 {
 		sw.DeleteChildren(ki.DestroyKids)
 		return
@@ -275,6 +275,6 @@ func (sw *Switches) ConfigSwitches(sc *Scene) {
 	}
 }
 
-func (sw *Switches) ConfigWidget(sc *Scene) {
-	sw.ConfigSwitches(sc)
+func (sw *Switches) ConfigWidget() {
+	sw.ConfigSwitches()
 }

--- a/gi/tabs.go
+++ b/gi/tabs.go
@@ -366,7 +366,7 @@ func (ts *Tabs) RecycleTabWidget(label string, sel bool, typ *gti.Type, name ...
 		return wi
 	}
 	wi, _ := AsWidget(fr.NewChild(typ, fr.Nm))
-	wi.Config(ts.Sc)
+	wi.Config()
 	return wi
 }
 
@@ -408,7 +408,7 @@ func (ts *Tabs) DeleteTabIndex(idx int, destroy bool) (*Frame, string, bool) {
 }
 
 // ConfigNewTabButton configures the new tab + button at end of list of tabs
-func (ts *Tabs) ConfigNewTabButton(sc *Scene) bool {
+func (ts *Tabs) ConfigNewTabButton() bool {
 	sz := ts.NTabs()
 	tb := ts.Tabs()
 	ntb := len(tb.Kids)
@@ -436,7 +436,7 @@ func (ts *Tabs) ConfigNewTabButton(sc *Scene) bool {
 // ConfigWidget initializes the tab widget children if it hasn't been done yet.
 // only the 2 primary children (Frames) need to be configured.
 // no re-config needed when adding / deleting tabs -- just new layout.
-func (ts *Tabs) ConfigWidget(sc *Scene) {
+func (ts *Tabs) ConfigWidget() {
 	if len(ts.Kids) != 0 {
 		return
 	}
@@ -445,20 +445,20 @@ func (ts *Tabs) ConfigWidget(sc *Scene) {
 	})
 	NewFrame(ts, "tabs")
 	NewFrame(ts, "frame")
-	ts.ConfigNewTabButton(sc)
+	ts.ConfigNewTabButton()
 }
 
 // Tabs returns the layout containing the tabs (the first element within us).
 // It configures the Tabs if necessary.
 func (ts *Tabs) Tabs() *Frame {
-	ts.ConfigWidget(ts.Sc)
+	ts.ConfigWidget()
 	return ts.Child(0).(*Frame)
 }
 
 // Frame returns the stacked frame layout (the second element within us).
 // It configures the Tabs if necessary.
 func (ts *Tabs) Frame() *Frame {
-	ts.ConfigWidget(ts.Sc)
+	ts.ConfigWidget()
 	return ts.Child(1).(*Frame)
 }
 
@@ -488,8 +488,8 @@ func (ts *Tabs) RenumberTabs() {
 }
 
 // RenderTabSeps renders the separators between tabs
-func (ts *Tabs) RenderTabSeps(sc *Scene) {
-	rs, pc, st := ts.RenderLock(sc)
+func (ts *Tabs) RenderTabSeps() {
+	rs, pc, st := ts.RenderLock()
 	defer ts.RenderUnlock(rs)
 
 	// just like with standard separator, use top width like CSS
@@ -511,12 +511,12 @@ func (ts *Tabs) RenderTabSeps(sc *Scene) {
 	pc.FillStrokeClear(rs)
 }
 
-func (ts *Tabs) Render(sc *Scene) {
-	if ts.PushBounds(sc) {
-		ts.RenderScrolls(sc)
-		ts.RenderChildren(sc)
-		ts.RenderTabSeps(sc)
-		ts.PopBounds(sc)
+func (ts *Tabs) Render() {
+	if ts.PushBounds() {
+		ts.RenderScrolls()
+		ts.RenderChildren()
+		ts.RenderTabSeps()
+		ts.PopBounds()
 	}
 }
 
@@ -638,18 +638,18 @@ func (tb *Tab) Tabs() *Tabs {
 	return AsTabs(ts)
 }
 
-func (tb *Tab) ConfigParts(sc *Scene) {
+func (tb *Tab) ConfigParts() {
 	if tb.MaxChars > 0 {
 		tb.Text = elide.Middle(tb.Text, tb.MaxChars)
 	}
 	if tb.DeleteButton {
-		tb.ConfigPartsDeleteButton(sc)
+		tb.ConfigPartsDeleteButton()
 		return
 	}
-	tb.Button.ConfigParts(sc) // regular
+	tb.Button.ConfigParts() // regular
 }
 
-func (tb *Tab) ConfigPartsDeleteButton(sc *Scene) {
+func (tb *Tab) ConfigPartsDeleteButton() {
 	parts := tb.NewParts()
 	config := ki.Config{}
 	icIdx, lbIdx := tb.ConfigPartsIconLabel(&config, tb.Icon, tb.Text)
@@ -685,6 +685,6 @@ func (tb *Tab) ConfigPartsDeleteButton(sc *Scene) {
 	}
 }
 
-func (tb *Tab) ConfigWidget(sc *Scene) {
-	tb.ConfigParts(sc)
+func (tb *Tab) ConfigWidget() {
+	tb.ConfigParts()
 }

--- a/gi/testing.go
+++ b/gi/testing.go
@@ -46,7 +46,7 @@ func (sc *Scene) AssertPixelsOnShow(t images.TestingT, filename string, fun ...f
 	sc.OnShow(func(e events.Event) {
 		if len(fun) > 0 {
 			fun[0]()
-			sc.DoNeedsRender(sc)
+			sc.DoNeedsRender()
 		}
 		sc.AssertPixels(t, filename)
 		showed <- struct{}{}

--- a/gi/textfield.go
+++ b/gi/textfield.go
@@ -1213,7 +1213,7 @@ func (tf *TextField) CursorSprite(on bool) *Sprite {
 }
 
 // RenderSelect renders the selected region, if any, underneath the text
-func (tf *TextField) RenderSelect(sc *Scene) {
+func (tf *TextField) RenderSelect() {
 	if !tf.HasSelection() {
 		return
 	}
@@ -1231,7 +1231,7 @@ func (tf *TextField) RenderSelect(sc *Scene) {
 
 	spos := tf.CharStartPos(effst, false)
 
-	rs := &sc.RenderState
+	rs := &tf.Sc.RenderState
 	pc := &rs.Paint
 	tsz := tf.TextWidth(effst, effed)
 	pc.FillBox(rs, spos, mat32.NewVec2(tsz, tf.FontHeight), &tf.SelectColor)
@@ -1688,7 +1688,7 @@ func (tf *TextField) HandleTextFieldEvents() {
 	tf.HandleTextFieldClose()
 }
 
-func (tf *TextField) ConfigParts(sc *Scene) {
+func (tf *TextField) ConfigParts() {
 	parts := tf.NewParts()
 	if tf.IsReadOnly() || (tf.LeadingIcon.IsNil() && tf.TrailingIcon.IsNil()) {
 		parts.DeleteChildren(ki.DestroyKids)
@@ -1722,30 +1722,30 @@ func (tf *TextField) ConfigParts(sc *Scene) {
 		}
 		parts.Update()
 		parts.UpdateEnd(updt)
-		tf.SetNeedsLayoutUpdate(sc, updt)
+		tf.SetNeedsLayout(updt)
 	}
 }
 
 ////////////////////////////////////////////////////
 //  Widget Interface
 
-func (tf *TextField) ConfigWidget(sc *Scene) {
+func (tf *TextField) ConfigWidget() {
 	tf.EditTxt = []rune(tf.Txt)
 	tf.Edited = false
-	tf.ConfigParts(sc)
+	tf.ConfigParts()
 }
 
 // StyleTextField does text field styling -- sets StyMu Lock
-func (tf *TextField) StyleTextField(sc *Scene) {
+func (tf *TextField) StyleTextField() {
 	tf.StyMu.Lock()
 	tf.SetAbilities(!tf.IsReadOnly(), abilities.Focusable)
-	tf.ApplyStyleWidget(sc)
+	tf.ApplyStyleWidget()
 	tf.CursorWidth.ToDots(&tf.Styles.UnContext)
 	tf.StyMu.Unlock()
 }
 
-func (tf *TextField) ApplyStyle(sc *Scene) {
-	tf.StyleTextField(sc)
+func (tf *TextField) ApplyStyle() {
+	tf.StyleTextField()
 }
 
 func (tf *TextField) UpdateRenderAll() bool {
@@ -1759,8 +1759,8 @@ func (tf *TextField) UpdateRenderAll() bool {
 	return true
 }
 
-func (tf *TextField) SizeUp(sc *Scene) {
-	tf.WidgetBase.SizeUp(sc)
+func (tf *TextField) SizeUp() {
+	tf.WidgetBase.SizeUp()
 	tmptxt := tf.EditTxt
 	if len(tf.Txt) == 0 && len(tf.Placeholder) > 0 {
 		tf.EditTxt = []rune(tf.Placeholder)
@@ -1785,8 +1785,8 @@ func (tf *TextField) SizeUp(sc *Scene) {
 	tf.EditTxt = tmptxt
 }
 
-func (tf *TextField) ScenePos(sc *Scene) {
-	tf.WidgetBase.ScenePos(sc)
+func (tf *TextField) ScenePos() {
+	tf.WidgetBase.ScenePos()
 	tf.SetEffPosAndSize()
 }
 
@@ -1812,16 +1812,16 @@ func (tf *TextField) SetEffPosAndSize() {
 	tf.EffPos = pos.Ceil()
 }
 
-func (tf *TextField) RenderTextField(sc *Scene) {
-	rs, _, _ := tf.RenderLock(sc)
+func (tf *TextField) RenderTextField() {
+	rs, _, _ := tf.RenderLock()
 	defer tf.RenderUnlock(rs)
 
 	tf.AutoScroll() // inits paint with our style
 	st := &tf.Styles
 	st.Font = paint.OpenFont(st.FontRender(), &st.UnContext)
-	tf.RenderStdBox(sc, st)
+	tf.RenderStdBox(st)
 	cur := tf.EditTxt[tf.StartPos:tf.EndPos]
-	tf.RenderSelect(sc)
+	tf.RenderSelect()
 	pos := tf.EffPos
 	if len(tf.EditTxt) == 0 && len(tf.Placeholder) > 0 {
 		prevColor := st.Color
@@ -1838,12 +1838,12 @@ func (tf *TextField) RenderTextField(sc *Scene) {
 	}
 }
 
-func (tf *TextField) Render(sc *Scene) {
+func (tf *TextField) Render() {
 	if tf.StateIs(states.Focused) && BlinkingTextField == tf {
 		tf.ScrollLayoutToCursor()
 	}
-	if tf.PushBounds(sc) {
-		tf.RenderTextField(sc)
+	if tf.PushBounds() {
+		tf.RenderTextField()
 		if !tf.IsReadOnly() {
 			if tf.StateIs(states.Focused) {
 				tf.StartCursor()
@@ -1851,9 +1851,9 @@ func (tf *TextField) Render(sc *Scene) {
 				tf.StopCursor()
 			}
 		}
-		tf.RenderParts(sc)
-		tf.RenderChildren(sc)
-		tf.PopBounds(sc)
+		tf.RenderParts()
+		tf.RenderChildren()
+		tf.PopBounds()
 	}
 }
 

--- a/gi/topappbar.go
+++ b/gi/topappbar.go
@@ -157,24 +157,24 @@ func (tb *TopAppBar) IsVisible() bool {
 	return tb.WidgetBase.IsVisible() && len(tb.Kids) > 0
 }
 
-func (tb *TopAppBar) SizeUp(sc *Scene) {
-	tb.AllItemsToChildren(sc)
-	tb.Frame.SizeUp(sc)
+func (tb *TopAppBar) SizeUp() {
+	tb.AllItemsToChildren()
+	tb.Frame.SizeUp()
 }
 
 // todo: try doing move to overflow in Final
 
-func (tb *TopAppBar) SizeDown(sc *Scene, iter int) bool {
-	redo := tb.Frame.SizeDown(sc, iter)
+func (tb *TopAppBar) SizeDown(iter int) bool {
+	redo := tb.Frame.SizeDown(iter)
 	if iter == 0 {
 		return true // ensure a second pass
 	}
-	tb.MoveToOverflow(sc)
+	tb.MoveToOverflow()
 	return redo
 }
 
-func (tb *TopAppBar) SizeFromChildren(sc *Scene, iter int, pass LayoutPasses) mat32.Vec2 {
-	csz := tb.Frame.SizeFromChildren(sc, iter, pass)
+func (tb *TopAppBar) SizeFromChildren(iter int, pass LayoutPasses) mat32.Vec2 {
+	csz := tb.Frame.SizeFromChildren(iter, pass)
 	if pass == SizeUpPass || (pass == SizeDownPass && iter == 0) {
 		ovsz := tb.OverflowButton.Geom.Size.Actual.Total.X
 		csz.X = ovsz // present the minimum size initially
@@ -187,7 +187,7 @@ func (tb *TopAppBar) SizeFromChildren(sc *Scene, iter int, pass LayoutPasses) ma
 // so the full set is considered for the next layout round,
 // and ensures the overflow button is made and moves it
 // to the end of the list.
-func (tb *TopAppBar) AllItemsToChildren(sc *Scene) {
+func (tb *TopAppBar) AllItemsToChildren() {
 	if tb.OverflowButton == nil {
 		ic := icons.MoreVert
 		if tb.Styles.Direction != styles.Row {
@@ -196,7 +196,7 @@ func (tb *TopAppBar) AllItemsToChildren(sc *Scene) {
 		tb.OverflowButton = NewButton(tb, "overflow-menu").SetIcon(ic).
 			SetTooltip("Overflow toolbar items and additional menu items")
 		tb.OverflowButton.Menu = tb.OverflowMenu
-		tb.OverflowButton.Config(sc)
+		tb.OverflowButton.Config()
 	}
 	if len(tb.OverflowItems) > 0 {
 		tb.Kids = append(tb.Kids, tb.OverflowItems...)
@@ -225,7 +225,7 @@ func (tb *TopAppBar) ParentSize() float32 {
 }
 
 // MoveToOverflow moves overflow out of children to the OverflowItems list
-func (tb *TopAppBar) MoveToOverflow(sc *Scene) {
+func (tb *TopAppBar) MoveToOverflow() {
 	ma := tb.Styles.Direction.Dim()
 	avail := tb.ParentSize()
 	ovsz := tb.OverflowButton.Geom.Size.Actual.Total.Dim(ma)
@@ -268,7 +268,7 @@ func (tb *TopAppBar) OverflowMenu(m *Scene) {
 			}
 			cl := k.This().Clone()
 			m.AddChild(cl)
-			cl.This().(Widget).Config(m)
+			cl.This().(Widget).Config()
 		}
 		if nm > 1 { // default includes sep
 			NewSeparator(m)

--- a/gi/transition.go
+++ b/gi/transition.go
@@ -39,7 +39,7 @@ func (wb *WidgetBase) Transition(value any, to any, duration time.Duration, timi
 			inc := timingFunc(prop)
 			nv := vn + inc*diff
 			grr.Log0(laser.SetRobust(value, nv))
-			wb.SetNeedsRender()
+			wb.SetNeedsRender(true)
 		}
 		tick.Stop()
 	}()

--- a/gi/widget.go
+++ b/gi/widget.go
@@ -42,14 +42,14 @@ type Widget interface {
 	// ApplyStyle must generally be called after Config - it is called
 	// automatically when Scene is first shown, but must be called
 	// manually thereafter as needed after configuration changes.
-	// See ReConfig for a convenience function that does both.
+	// See Update for a convenience function that does both.
 	// ConfigScene on Scene handles full tree configuration.
 	// This config calls UpdateStart / End, and SetNeedsLayout,
 	// and calls ConfigWidget to do the actual configuration,
 	// so it does not need to manage this housekeeping.
 	// Thus, this Config call is typically never changed, and
 	// all custom configuration should happen in ConfigWidget.
-	Config(sc *Scene)
+	Config()
 
 	// ConfigWidget does the actual configuration of the widget,
 	// primarily configuring its Parts.
@@ -57,7 +57,7 @@ type Widget interface {
 	// (i.e., use Parts.ConfigChildren with Config).
 	// Outer Config call handles all the other infrastructure,
 	// so this call just does the core configuration.
-	ConfigWidget(sc *Scene)
+	ConfigWidget()
 
 	// Update calls Config and ApplyStyle on this widget.
 	// This should be called if any config options are changed
@@ -77,15 +77,15 @@ type Widget interface {
 	SetAbilities(on bool, able ...enums.BitFlag) *WidgetBase
 
 	// ApplyStyle applies style functions to the widget based on current state.
-	// It is typically not overridden -- set style funcs to apply custom styling.
-	ApplyStyle(sc *Scene)
+	// It is typically not overridden; instead, call Style to apply custom styling.
+	ApplyStyle()
 
 	// SizeUp (bottom-up) gathers Actual sizes from our Children & Parts,
 	// based on Styles.Min / Max sizes and actual content sizing
 	// (e.g., text size).  Flexible elements (e.g., Label, Flex Wrap,
 	// TopAppBar) should reserve the _minimum_ size possible at this stage,
 	// and then Grow based on SizeDown allocation.
-	SizeUp(sc *Scene)
+	SizeUp()
 
 	// SizeDown (top-down, multiple iterations possible) provides top-down
 	// size allocations based initially on Scene available size and
@@ -97,7 +97,7 @@ type Widget interface {
 	// However, do NOT grow the Actual size to match Alloc at this stage,
 	// as Actual sizes must always represent the minimums (see Position).
 	// Returns true if any change in Actual size occurred.
-	SizeDown(sc *Scene, iter int) bool
+	SizeDown(iter int) bool
 
 	// SizeFinal: (bottom-up) similar to SizeUp but done at the end of the
 	// Sizing phase: first grows widget Actual sizes based on their Grow
@@ -105,25 +105,25 @@ type Widget interface {
 	// actual Size information for layouts to register their actual sizes
 	// prior to positioning, which requires accurate Actual vs. Alloc
 	// sizes to perform correct alignment calculations.
-	SizeFinal(sc *Scene)
+	SizeFinal()
 
 	// Position uses the final sizes to set relative positions within layouts
 	// according to alignment settings, and Grow elements to their actual
 	// Alloc size per Styles settings and widget-specific behavior.
-	Position(sc *Scene)
+	Position()
 
 	// ScenePos computes scene-based absolute positions and final BBox
 	// bounding boxes for rendering, based on relative positions from
 	// Position step and parents accumulated position and scroll offset.
 	// This is the only step needed when scrolling (very fast).
-	ScenePos(sc *Scene)
+	ScenePos()
 
 	// Render performs actual rendering pass.  Bracket the render calls in
 	// PushBounds / PopBounds and a false from PushBounds indicates that
 	// the node is invisible and should not be rendered.
 	// If Parts are present, RenderParts is called by default.
 	// Layouts or other widgets that manage children should call RenderChildren.
-	Render(sc *Scene)
+	Render()
 
 	// On adds an event listener function for the given event type
 	On(etype events.Types, fun func(e events.Event)) *WidgetBase

--- a/giv/argview.go
+++ b/giv/argview.go
@@ -130,7 +130,7 @@ func (av *ArgView) ConfigArgsGrid() {
 		w, wb := gi.AsWidget(sg.Child((i * 2) + 1))
 		if wb.Class == "" {
 			wb.Class = "configed"
-			arg.ConfigWidget(w, av.Sc)
+			arg.ConfigWidget(w)
 		} else {
 			arg.AsValueBase().Widget = w
 			arg.UpdateWidget()

--- a/giv/argview.go
+++ b/giv/argview.go
@@ -60,7 +60,7 @@ func (av *ArgView) OnInit() {
 }
 
 // Config configures the view
-func (av *ArgView) ConfigWidget(vp *gi.Scene) {
+func (av *ArgView) ConfigWidget() {
 	config := ki.Config{}
 	config.Add(gi.LabelType, "title")
 	config.Add(gi.FrameType, "args-grid")
@@ -115,7 +115,7 @@ func (av *ArgView) ConfigArgsGrid() {
 	}
 	mods, updt := sg.ConfigChildren(config) // not sure if always unique?
 	if mods {
-		av.SetNeedsLayoutUpdate(av.Sc, updt)
+		av.SetNeedsLayout(updt)
 	} else {
 		updt = sg.UpdateStart()
 	}

--- a/giv/colormap.go
+++ b/giv/colormap.go
@@ -63,7 +63,7 @@ func (cv *ColorMapView) ChooseColorMap() {
 	}
 	si := 0
 	d := gi.NewBody().AddTitle("Select a color map").AddText("Choose color map to use from among available list")
-	NewSliceView(d).SetSlice(&sl).SetSelVal(cur).BindSelectDialog(d.Sc, &si)
+	NewSliceView(d).SetSlice(&sl).SetSelVal(cur).BindSelectDialog(&si)
 	d.AddBottomBar(func(pw gi.Widget) {
 		d.AddOk(pw).OnClick(func(e events.Event) {
 			if si >= 0 {
@@ -191,7 +191,7 @@ func (vv *ColorMapValue) ConfigDialog(d *gi.Body) (bool, func()) {
 	sl := colormap.AvailMapsList()
 	cur := laser.ToString(vv.Value.Interface())
 	si := 0
-	NewSliceView(d).SetSlice(&sl).SetSelVal(cur).BindSelectDialog(d.Sc, &si)
+	NewSliceView(d).SetSlice(&sl).SetSelVal(cur).BindSelectDialog(&si)
 	return true, func() {
 		if si >= 0 {
 			vv.SetValue(sl[si])

--- a/giv/colormap.go
+++ b/giv/colormap.go
@@ -166,7 +166,7 @@ func (vv *ColorMapValue) UpdateWidget() {
 	bt.SetText(txt)
 }
 
-func (vv *ColorMapValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *ColorMapValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return

--- a/giv/colormap.go
+++ b/giv/colormap.go
@@ -43,7 +43,7 @@ func (cv *ColorMapView) OnInit() {
 // SetColorMap sets the color map and triggers a display update
 func (cv *ColorMapView) SetColorMap(cmap *colormap.Map) {
 	cv.Map = cmap
-	cv.SetNeedsRender()
+	cv.SetNeedsRender(true)
 }
 
 // SetColorMapAction sets the color map and triggers a display update
@@ -51,7 +51,7 @@ func (cv *ColorMapView) SetColorMap(cmap *colormap.Map) {
 func (cv *ColorMapView) SetColorMapAction(cmap *colormap.Map) {
 	cv.Map = cmap
 	cv.SendChange()
-	cv.SetNeedsRender()
+	cv.SetNeedsRender(true)
 }
 
 // ChooseColorMap pulls up a chooser to select a color map
@@ -85,11 +85,11 @@ func (cv *ColorMapView) HandleColorMapEvents() {
 
 }
 
-func (cv *ColorMapView) RenderColorMap(sc *gi.Scene) {
+func (cv *ColorMapView) RenderColorMap() {
 	if cv.Map == nil {
 		cv.Map = colormap.StdMaps["ColdHot"]
 	}
-	rs := &sc.RenderState
+	rs := &cv.Sc.RenderState
 	rs.Lock()
 	pc := &rs.Paint
 
@@ -127,11 +127,11 @@ func (cv *ColorMapView) RenderColorMap(sc *gi.Scene) {
 	rs.Unlock()
 }
 
-func (cv *ColorMapView) Render(sc *gi.Scene) {
-	if cv.PushBounds(sc) {
-		cv.RenderColorMap(sc)
-		cv.RenderChildren(sc)
-		cv.PopBounds(sc)
+func (cv *ColorMapView) Render() {
+	if cv.PushBounds() {
+		cv.RenderColorMap()
+		cv.RenderChildren()
+		cv.PopBounds()
 	}
 }
 
@@ -175,7 +175,7 @@ func (vv *ColorMapValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)

--- a/giv/colorview.go
+++ b/giv/colorview.go
@@ -696,7 +696,7 @@ func (vv *ColorNameValue) ConfigDialog(d *gi.Body) (bool, func()) {
 		}
 	}
 	si := 0
-	NewTableView(d).SetSlice(&sl).SetSelIdx(curRow).BindSelectDialog(d.Sc, &si)
+	NewTableView(d).SetSlice(&sl).SetSelIdx(curRow).BindSelectDialog(&si)
 	return true, func() {
 		if si >= 0 {
 			vv.SetValue(sl[si].Name)

--- a/giv/colorview.go
+++ b/giv/colorview.go
@@ -65,7 +65,7 @@ func (cv *ColorView) SetHCT(hct hct.HCT) *ColorView {
 }
 
 // Config configures a standard setup of entire view
-func (cv *ColorView) ConfigWidget(sc *gi.Scene) {
+func (cv *ColorView) ConfigWidget() {
 	if cv.HasChildren() {
 		return
 	}
@@ -570,10 +570,10 @@ func (vv *ColorValue) UpdateWidget() {
 	}
 	vv.CreateTempIfNotPtr()
 	bt := vv.Widget.(*gi.Button)
-	bt.SetNeedsRender()
+	bt.SetNeedsRender(true)
 }
 
-func (vv *ColorValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *ColorValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -606,7 +606,7 @@ func (vv *ColorValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 		// TODO: use hct contrast color
 		s.Color = colors.AsRGBA(hsl.ContrastColor(dclr))
 	})
-	bt.Config(sc)
+	bt.Config()
 	vv.UpdateWidget()
 }
 
@@ -653,7 +653,7 @@ func (vv *ColorNameValue) UpdateWidget() {
 	bt.SetText(txt)
 }
 
-func (vv *ColorNameValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *ColorNameValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -662,7 +662,7 @@ func (vv *ColorNameValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)

--- a/giv/fileview.go
+++ b/giv/fileview.go
@@ -237,11 +237,11 @@ var FileViewKindColorMap = map[string]string{
 	"folder": "pref(link)",
 }
 
-func (fv *FileView) ConfigWidget(sc *gi.Scene) {
-	fv.ConfigFileView(sc)
+func (fv *FileView) ConfigWidget() {
+	fv.ConfigFileView()
 }
 
-func (fv *FileView) ConfigFileView(sc *gi.Scene) {
+func (fv *FileView) ConfigFileView() {
 	if fv.HasChildren() {
 		return
 	}
@@ -277,7 +277,7 @@ func (fv *FileView) ConfigPathBar() {
 	pl := gi.NewLabel(pr, "path-lbl").SetText("Path:")
 	pl.Tooltip = "Path to look for files in: can select from list of recent paths, or edit a value directly"
 	pf := gi.NewChooser(pr, "path").SetEditable(true)
-	pf.ConfigParts(fv.Sc)
+	pf.ConfigParts()
 	pft, found := pf.TextField()
 	if found {
 		pft.SetCompleter(fv, fv.PathComplete, fv.PathCompleteEdit)
@@ -753,8 +753,8 @@ func (fv *FileView) SaveSortPrefs() {
 	gi.Prefs.Save()
 }
 
-func (fv *FileView) ApplyStyle(sc *gi.Scene) {
-	fv.Frame.ApplyStyle(sc)
+func (fv *FileView) ApplyStyle() {
+	fv.Frame.ApplyStyle()
 	sf := fv.SelField()
 	sf.StartFocus() // need to call this when window is actually active
 }

--- a/giv/histyleview.go
+++ b/giv/histyleview.go
@@ -36,7 +36,7 @@ func (vv *HiStyleValue) UpdateWidget() {
 	bt.SetText(txt)
 }
 
-func (vv *HiStyleValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *HiStyleValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -45,7 +45,7 @@ func (vv *HiStyleValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)

--- a/giv/histyleview.go
+++ b/giv/histyleview.go
@@ -60,7 +60,7 @@ func (vv *HiStyleValue) OpenDialog(ctx gi.Widget, fun func()) { OpenValueDialog(
 func (vv *HiStyleValue) ConfigDialog(d *gi.Body) (bool, func()) {
 	si := 0
 	cur := laser.ToString(vv.Value.Interface())
-	NewSliceView(d).SetSlice(&histyle.StyleNames).SetSelVal(cur).BindSelectDialog(d.Sc, &si)
+	NewSliceView(d).SetSlice(&histyle.StyleNames).SetSelVal(cur).BindSelectDialog(&si)
 	return true, func() {
 		if si >= 0 {
 			hs := histyle.StyleNames[si]

--- a/giv/inspector.go
+++ b/giv/inspector.go
@@ -63,7 +63,7 @@ func (is *Inspector) Update() { //gti:add
 		return
 	}
 	if w, ok := is.KiRoot.(gi.Widget); ok {
-		w.AsWidget().SetNeedsRender()
+		w.AsWidget().SetNeedsRender(true)
 	}
 }
 
@@ -88,7 +88,7 @@ func (is *Inspector) SaveAs(filename gi.FileName) { //gti:add
 	grr.Log0(jsons.Save(is.KiRoot, string(filename)))
 	is.Changed = false
 	is.Filename = filename
-	is.SetNeedsRender() // notify our editor
+	is.SetNeedsRender(true) // notify our editor
 }
 
 // Open opens tree from given filename, in a standard JSON-formatted file
@@ -98,7 +98,7 @@ func (is *Inspector) Open(filename gi.FileName) { //gti:add
 	}
 	grr.Log0(jsons.Open(is.KiRoot, string(filename)))
 	is.Filename = filename
-	is.SetNeedsRender() // notify our editor
+	is.SetNeedsRender(true) // notify our editor
 }
 
 // EditColorScheme pulls up a window to edit the current color scheme
@@ -195,7 +195,7 @@ func (is *Inspector) SelectionMonitor() {
 
 			updt = sc.UpdateStartAsync()
 			sc.SelectedWidget = sw
-			sw.AsWidget().SetNeedsRenderUpdate(sc, updt)
+			sw.AsWidget().SetNeedsRender(updt)
 			sc.UpdateEndAsyncRender(updt)
 		}
 	}
@@ -209,12 +209,12 @@ func (is *Inspector) SetRoot(root ki.Ki) {
 		is.KiRoot = root
 		// ge.GetAllUpdates(root)
 	}
-	is.Config(is.Sc)
+	is.Config()
 	is.UpdateEnd(updt)
 }
 
 // Config configures the widget
-func (is *Inspector) ConfigWidget(sc *gi.Scene) {
+func (is *Inspector) ConfigWidget() {
 	if is.KiRoot == nil {
 		return
 	}

--- a/giv/keychordview.go
+++ b/giv/keychordview.go
@@ -41,7 +41,7 @@ func (vv *KeyChordValue) UpdateWidget() {
 	kc.SetText(txt)
 }
 
-func (vv *KeyChordValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *KeyChordValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -49,7 +49,7 @@ func (vv *KeyChordValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.Widget = w
 	vv.StdConfigWidget(w)
 	kc := vv.Widget.(*KeyChordEdit)
-	kc.Config(sc)
+	kc.Config()
 	kc.OnChange(func(e events.Event) {
 		if vv.SetValue(key.Chord(kc.Text)) {
 			vv.UpdateWidget()

--- a/giv/keymapsview.go
+++ b/giv/keymapsview.go
@@ -109,7 +109,7 @@ func (vv *KeyMapValue) ConfigDialog(d *gi.Body) (bool, func()) {
 	si := 0
 	cur := laser.ToString(vv.Value.Interface())
 	_, curRow, _ := keyfun.AvailMaps.MapByName(keyfun.MapName(cur))
-	NewTableView(d).SetSlice(&keyfun.AvailMaps).SetSelIdx(curRow).BindSelectDialog(d.Sc, &si)
+	NewTableView(d).SetSlice(&keyfun.AvailMaps).SetSelIdx(curRow).BindSelectDialog(&si)
 	return true, func() {
 		if si >= 0 {
 			km := keyfun.AvailMaps[si]

--- a/giv/keymapsview.go
+++ b/giv/keymapsview.go
@@ -84,7 +84,7 @@ func (vv *KeyMapValue) UpdateWidget() {
 	bt.SetText(txt)
 }
 
-func (vv *KeyMapValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *KeyMapValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -93,7 +93,7 @@ func (vv *KeyMapValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)

--- a/giv/mapview.go
+++ b/giv/mapview.go
@@ -107,7 +107,7 @@ func (mv *MapView) UpdateValues() {
 }
 
 // Config configures the view
-func (mv *MapView) ConfigWidget(sc *gi.Scene) {
+func (mv *MapView) ConfigWidget() {
 	if !mv.HasChildren() {
 		gi.NewFrame(mv, "map-grid")
 	}
@@ -146,7 +146,6 @@ func (mv *MapView) ConfigMapGrid() {
 	if laser.AnyIsNil(mv.Map) {
 		return
 	}
-	sc := mv.Sc
 	sg := mv.MapGrid()
 	config := ki.Config{}
 	// always start fresh!
@@ -212,7 +211,7 @@ func (mv *MapView) ConfigMapGrid() {
 	}
 	mods, updt := sg.ConfigChildren(config)
 	if mods {
-		sg.SetNeedsLayoutUpdate(sc, updt)
+		sg.SetNeedsLayout(updt)
 	} else {
 		updt = sg.UpdateStart() // cover rest of updates, which can happen even if same config
 	}
@@ -227,8 +226,8 @@ func (mv *MapView) ConfigMapGrid() {
 		})
 		keyw := sg.Child(i * ncol).(gi.Widget)
 		w := sg.Child(i*ncol + 1).(gi.Widget)
-		kv.ConfigWidget(keyw, sc)
-		vv.ConfigWidget(w, sc)
+		kv.ConfigWidget(keyw)
+		vv.ConfigWidget(w)
 		if ifaceType {
 			typw := sg.Child(i*ncol + 2).(*gi.Chooser)
 			typw.SetTypes(valtypes, false, true, 50)

--- a/giv/mapviewinline.go
+++ b/giv/mapviewinline.go
@@ -104,12 +104,12 @@ func (mv *MapViewInline) SetMap(mp any) *MapViewInline {
 	return mv
 }
 
-func (mv *MapViewInline) ConfigWidget(sc *gi.Scene) {
-	mv.ConfigMap(sc)
+func (mv *MapViewInline) ConfigWidget() {
+	mv.ConfigMap()
 }
 
 // ConfigMap configures children for map view
-func (mv *MapViewInline) ConfigMap(sc *gi.Scene) bool {
+func (mv *MapViewInline) ConfigMap() bool {
 	if laser.AnyIsNil(mv.Map) {
 		return false
 	}
@@ -168,8 +168,8 @@ func (mv *MapViewInline) ConfigMap(sc *gi.Scene) bool {
 		w, wb := gi.AsWidget(mv.Child((i * 2) + 1))
 		kw, kwb := gi.AsWidget(mv.Child(i * 2))
 		if wb.Class == "" {
-			vv.ConfigWidget(w, sc)
-			kv.ConfigWidget(kw, sc)
+			vv.ConfigWidget(w)
+			kv.ConfigWidget(kw)
 		} else {
 			wb.Class = "configed"
 			kwb.Class = "configed"

--- a/giv/sliceview.go
+++ b/giv/sliceview.go
@@ -146,7 +146,7 @@ type SliceViewer interface {
 
 	// ConfigRows configures VisRows worth of widgets
 	// to display slice data.
-	ConfigRows(sc *gi.Scene)
+	ConfigRows()
 
 	// UpdateWidgets updates the row widget display to
 	// represent the current state of the slice data,
@@ -414,41 +414,41 @@ func (sv *SliceViewBase) IsNil() bool {
 }
 
 // BindSelectDialog makes the slice view a read-only selection slice view and then
-// binds its events to the given dialog and its current selection index to the given value.
-func (sv *SliceViewBase) BindSelectDialog(sc *gi.Scene, val *int) *SliceViewBase {
+// binds its events to its scene and its current selection index to the given value.
+func (sv *SliceViewBase) BindSelectDialog(val *int) *SliceViewBase {
 	sv.SetReadOnly(true)
 	sv.OnSelect(func(e events.Event) {
 		*val = sv.SelIdx
 	})
 	sv.OnDoubleClick(func(e events.Event) {
 		*val = sv.SelIdx
-		sc.Close()
+		sv.Sc.Close()
 	})
 	return sv
 }
 
 // Config configures a standard setup of the overall Frame
-func (sv *SliceViewBase) ConfigWidget(sc *gi.Scene) {
-	sv.ConfigSliceView(sc)
+func (sv *SliceViewBase) ConfigWidget() {
+	sv.ConfigSliceView()
 }
 
 // ConfigSliceView handles entire config.
 // ReConfig calls this, followed by ApplyStyleTree so we don't need to call that.
-func (sv *SliceViewBase) ConfigSliceView(sc *gi.Scene) {
+func (sv *SliceViewBase) ConfigSliceView() {
 	if sv.Is(SliceViewConfiged) {
 		sv.This().(SliceViewer).UpdateWidgets()
 		return
 	}
 	updt := sv.UpdateStart()
-	sv.ConfigFrame(sc)
-	sv.This().(SliceViewer).ConfigRows(sc)
+	sv.ConfigFrame()
+	sv.This().(SliceViewer).ConfigRows()
 	sv.This().(SliceViewer).UpdateWidgets()
 	sv.ConfigScroll()
-	sv.ApplyStyleTree(sc)
+	sv.ApplyStyleTree()
 	sv.UpdateEndLayout(updt)
 }
 
-func (sv *SliceViewBase) ConfigFrame(sc *gi.Scene) {
+func (sv *SliceViewBase) ConfigFrame() {
 	if sv.HasChildren() {
 		return
 	}
@@ -561,7 +561,7 @@ func (sv *SliceViewBase) UpdateScroll() {
 
 // ConfigRows configures VisRows worth of widgets
 // to display slice data.
-func (sv *SliceViewBase) ConfigRows(sc *gi.Scene) {
+func (sv *SliceViewBase) ConfigRows() {
 	sg := sv.This().(SliceViewer).SliceGrid()
 	if sg == nil {
 		return
@@ -619,7 +619,7 @@ func (sv *SliceViewBase) ConfigRows(sc *gi.Scene) {
 
 		w := ki.NewOfType(vtyp).(gi.Widget)
 		sg.SetChild(w, ridx+idxOff, valnm)
-		vv.ConfigWidget(w, sc)
+		vv.ConfigWidget(w)
 		wb := w.AsWidget()
 		wb.OnSelect(func(e events.Event) {
 			e.SetHandled()
@@ -665,8 +665,8 @@ func (sv *SliceViewBase) ConfigRows(sc *gi.Scene) {
 			}
 		}
 	}
-	sv.ConfigTree(sc)
-	sv.ApplyStyleTree(sc)
+	sv.ConfigTree()
+	sv.ApplyStyleTree()
 }
 
 // UpdateWidgets updates the row widget display to
@@ -1255,7 +1255,7 @@ func (sv *SliceViewBase) UpdateSelectIdx(idx int, sel bool) {
 			sv.SelIdx = idx
 			sv.SelectIdx(idx)
 		}
-		sv.ApplyStyleTree(sv.Sc)
+		sv.ApplyStyleTree()
 		sv.This().(SliceViewer).UpdateWidgets()
 		sv.Send(events.Select)
 	} else {
@@ -1429,7 +1429,7 @@ func (sv *SliceViewBase) SelectIdxAction(idx int, mode events.SelectModes) {
 		sv.UnselectIdx(idx)
 	}
 	sv.This().(SliceViewer).UpdateWidgets()
-	sv.ApplyStyleTree(sv.Sc)
+	sv.ApplyStyleTree()
 }
 
 // UnselectIdxAction unselects this idx (if selected) -- and emits a signal
@@ -2104,8 +2104,8 @@ func (sg *SliceViewGrid) OnInit() {
 	sg.Styles.Display = styles.Grid
 }
 
-func (sg *SliceViewGrid) SizeFromChildren(sc *gi.Scene, iter int, pass gi.LayoutPasses) mat32.Vec2 {
-	csz := sg.Frame.SizeFromChildren(sc, iter, pass)
+func (sg *SliceViewGrid) SizeFromChildren(iter int, pass gi.LayoutPasses) mat32.Vec2 {
+	csz := sg.Frame.SizeFromChildren(iter, pass)
 	rht, err := sg.LayImpl.RowHeight(0, 0)
 	if err != nil {
 		fmt.Println("SliceViewGrid Sizing Error:", err)
@@ -2132,14 +2132,14 @@ func (sg *SliceViewGrid) SizeFromChildren(sc *gi.Scene, iter int, pass gi.Layout
 	return csz
 }
 
-func (sv *SliceViewBase) SizeFinal(sc *gi.Scene) {
+func (sv *SliceViewBase) SizeFinal() {
 	sg := sv.This().(SliceViewer).SliceGrid()
 	if sv.VisRows != sg.VisRows {
 		sv.VisRows = sg.VisRows
 		// fmt.Println("vis rows:", sg.VisRows)
-		sv.This().(SliceViewer).ConfigRows(sc)
-		sg.SizeFinalUpdateChildrenSizes(sc)
+		sv.This().(SliceViewer).ConfigRows()
+		sg.SizeFinalUpdateChildrenSizes()
 	}
-	sv.Frame.SizeFinal(sc)
+	sv.Frame.SizeFinal()
 	// fmt.Println(sv, "layout")
 }

--- a/giv/sliceviewinline.go
+++ b/giv/sliceviewinline.go
@@ -123,12 +123,12 @@ func (sv *SliceViewInline) SetSlice(sl any) *SliceViewInline {
 	return sv
 }
 
-func (sv *SliceViewInline) ConfigWidget(sc *gi.Scene) {
-	sv.ConfigSlice(sc)
+func (sv *SliceViewInline) ConfigWidget() {
+	sv.ConfigSlice()
 }
 
 // ConfigSlice configures children for slice view
-func (sv *SliceViewInline) ConfigSlice(sc *gi.Scene) bool {
+func (sv *SliceViewInline) ConfigSlice() bool {
 	if laser.AnyIsNil(sv.Slice) {
 		return false
 	}
@@ -169,7 +169,7 @@ func (sv *SliceViewInline) ConfigSlice(sc *gi.Scene) bool {
 		if sv.SliceValView != nil {
 			vv.SetTags(sv.SliceValView.AllTags())
 		}
-		vv.ConfigWidget(w, sc)
+		vv.ConfigWidget(w)
 		if sv.IsReadOnly() {
 			w.AsWidget().SetReadOnly(true)
 		}

--- a/giv/structview.go
+++ b/giv/structview.go
@@ -118,19 +118,19 @@ func (sv *StructView) UpdateField(field string) {
 }
 
 // Config configures the view
-func (sv *StructView) ConfigWidget(sc *gi.Scene) {
+func (sv *StructView) ConfigWidget() {
 	if ks, ok := sv.Struct.(ki.Ki); ok {
 		if ks == nil || ks.This() == nil || ks.Is(ki.Deleted) {
 			return
 		}
 	}
 	if sv.HasChildren() {
-		sv.ConfigStructGrid(sc)
+		sv.ConfigStructGrid()
 		return
 	}
 	updt := sv.UpdateStart()
 	gi.NewFrame(sv, "struct-grid")
-	sv.ConfigStructGrid(sc)
+	sv.ConfigStructGrid()
 	sv.UpdateEndLayout(updt)
 }
 
@@ -158,7 +158,7 @@ func (sv *StructView) FieldTags(fld reflect.StructField) reflect.StructTag {
 
 // ConfigStructGrid configures the StructGrid for the current struct.
 // returns true if any fields changed.
-func (sv *StructView) ConfigStructGrid(sc *gi.Scene) bool {
+func (sv *StructView) ConfigStructGrid() bool {
 	if laser.AnyIsNil(sv.Struct) {
 		return false
 	}
@@ -302,7 +302,7 @@ func (sv *StructView) ConfigStructGrid(sc *gi.Scene) bool {
 		}
 		if wb.Class == "" {
 			wb.Class = "configed"
-			vv.ConfigWidget(w, sc)
+			vv.ConfigWidget(w)
 		} else {
 			vvb.Widget = w
 			vv.UpdateWidget()

--- a/giv/structviewinline.go
+++ b/giv/structviewinline.go
@@ -64,12 +64,12 @@ func (sv *StructViewInline) SetStruct(st any) *StructViewInline {
 	return sv
 }
 
-func (sv *StructViewInline) ConfigWidget(sc *gi.Scene) {
-	sv.ConfigStruct(sc)
+func (sv *StructViewInline) ConfigWidget() {
+	sv.ConfigStruct()
 }
 
 // ConfigStruct configures the children for the current struct
-func (sv *StructViewInline) ConfigStruct(sc *gi.Scene) bool {
+func (sv *StructViewInline) ConfigStruct() bool {
 	if laser.AnyIsNil(sv.Struct) {
 		return false
 	}
@@ -129,7 +129,7 @@ func (sv *StructViewInline) ConfigStruct(sc *gi.Scene) bool {
 		}
 		if wb.Class == "" {
 			wb.Class = "configed"
-			vv.ConfigWidget(w, sc)
+			vv.ConfigWidget(w)
 		} else {
 			vvb.Widget = w
 			vv.UpdateWidget()
@@ -163,7 +163,7 @@ func (sv *StructViewInline) UpdateFieldAction() {
 	if sv.HasViewIfs {
 		fmt.Println("did view if update")
 		sv.Update()
-		sv.SetNeedsLayout()
+		sv.SetNeedsLayout(true)
 	} else if sv.HasDefs {
 		updt := sv.UpdateStart()
 		for i, vv := range sv.FieldViews {
@@ -174,10 +174,10 @@ func (sv *StructViewInline) UpdateFieldAction() {
 	}
 }
 
-// func (sv *StructViewInline) SizeUp(sc *gi.Scene) {
-// 	updt := sv.ConfigStruct(sc)
+// func (sv *StructViewInline) SizeUp() {
+// 	updt := sv.ConfigStruct()
 // 	if updt {
-// 		sv.ApplyStyleTree(sc)
+// 		sv.ApplyStyleTree()
 // 	}
-// 	sv.Frame.SizeUp(sc)
+// 	sv.Frame.SizeUp()
 // }

--- a/giv/svgeditor.go
+++ b/giv/svgeditor.go
@@ -104,8 +104,8 @@ func (sve *Editor) SetTransform() {
 	sve.SetProp("transform", fmt.Sprintf("translate(%v,%v) scale(%v,%v)", sve.Trans.X, sve.Trans.Y, sve.Scale, sve.Scale))
 }
 
-func (sve *Editor) Render(sc *gi.Scene) {
-	if sve.PushBounds(sc) {
+func (sve *Editor) Render() {
+	if sve.PushBounds() {
 		// rs := &sve.Render
 		// if sve.Fill {
 		// 	sve.FillScene()
@@ -114,8 +114,8 @@ func (sve *Editor) Render(sc *gi.Scene) {
 		// 	sve.SetNormXForm()
 		// }
 		// rs.PushXForm(sve.Pnt.XForm)
-		sve.RenderChildren(sc) // we must do children first, then us!
-		sve.PopBounds(sc)
+		sve.RenderChildren() // we must do children first, then us!
+		sve.PopBounds()
 		// rs.PopXForm()
 		// fmt.Printf("geom.bounds: %v  geom: %v\n", svg.Geom.Bounds(), svg.Geom)
 	}

--- a/giv/tableview.go
+++ b/giv/tableview.go
@@ -271,26 +271,26 @@ func (tv *TableView) CacheVisFields() {
 }
 
 // Config configures the view
-func (tv *TableView) ConfigWidget(sc *gi.Scene) {
-	tv.ConfigTableView(sc)
+func (tv *TableView) ConfigWidget() {
+	tv.ConfigTableView()
 }
 
-func (tv *TableView) ConfigTableView(sc *gi.Scene) {
+func (tv *TableView) ConfigTableView() {
 	if tv.Is(SliceViewConfiged) {
 		tv.This().(SliceViewer).UpdateWidgets()
 		return
 	}
 	updt := tv.UpdateStart()
 	tv.SortSlice()
-	tv.ConfigFrame(sc)
-	tv.This().(SliceViewer).ConfigRows(sc)
+	tv.ConfigFrame()
+	tv.This().(SliceViewer).ConfigRows()
 	tv.This().(SliceViewer).UpdateWidgets()
 	tv.ConfigScroll()
-	tv.ApplyStyleTree(sc)
+	tv.ApplyStyleTree()
 	tv.UpdateEndLayout(updt)
 }
 
-func (tv *TableView) ConfigFrame(sc *gi.Scene) {
+func (tv *TableView) ConfigFrame() {
 	if tv.HasChildren() {
 		return
 	}
@@ -300,10 +300,10 @@ func (tv *TableView) ConfigFrame(sc *gi.Scene) {
 	gl.SetFlag(true, gi.LayoutNoKeys)
 	NewSliceViewGrid(gl, "grid")
 	gi.NewSlider(gl, "scrollbar")
-	tv.ConfigHeader(sc)
+	tv.ConfigHeader()
 }
 
-func (tv *TableView) ConfigHeader(sc *gi.Scene) {
+func (tv *TableView) ConfigHeader() {
 	sgh := tv.SliceHeader()
 	if sgh.HasChildren() || tv.NVisFields == 0 {
 		return
@@ -410,7 +410,7 @@ func (tv *TableView) RowWidgetNs() (nWidgPerRow, idxOff int) {
 // ConfigRows configures VisRows worth of widgets
 // to display slice data.  It should only be called
 // when NeedsConfigRows is true: when VisRows changes.
-func (tv *TableView) ConfigRows(sc *gi.Scene) {
+func (tv *TableView) ConfigRows() {
 	sg := tv.This().(SliceViewer).SliceGrid()
 	if sg == nil {
 		return
@@ -490,7 +490,7 @@ func (tv *TableView) ConfigRows(sc *gi.Scene) {
 			cidx := ridx + idxOff + fli
 			w := ki.NewOfType(vtyp).(gi.Widget)
 			sg.SetChild(w, cidx, valnm)
-			vv.ConfigWidget(w, sc)
+			vv.ConfigWidget(w)
 			wb := w.AsWidget()
 			wb.OnSelect(func(e events.Event) {
 				e.SetHandled()
@@ -535,8 +535,8 @@ func (tv *TableView) ConfigRows(sc *gi.Scene) {
 			}
 		}
 	}
-	tv.ConfigTree(sc)
-	tv.ApplyStyleTree(sc)
+	tv.ConfigTree()
+	tv.ApplyStyleTree()
 }
 
 // UpdateWidgets updates the row widget display to
@@ -939,8 +939,8 @@ func (tv *TableView) StdCtxtMenu(m *gi.Scene, idx int) {
 //////////////////////////////////////////////////////
 // 	Header layout
 
-func (tv *TableView) SizeFinal(sc *gi.Scene) {
-	tv.SliceViewBase.SizeFinal(sc)
+func (tv *TableView) SizeFinal() {
+	tv.SliceViewBase.SizeFinal()
 	sg := tv.This().(SliceViewer).SliceGrid()
 	sh := tv.SliceHeader()
 	sh.WidgetKidsIter(func(i int, kwi gi.Widget, kwb *gi.WidgetBase) bool {

--- a/giv/timeview.go
+++ b/giv/timeview.go
@@ -52,7 +52,7 @@ func (tv *TimeView) SetTime(tim time.Time) *TimeView {
 	return tv
 }
 
-func (tv *TimeView) ConfigWidget(sc *gi.Scene) {
+func (tv *TimeView) ConfigWidget() {
 	if tv.HasChildren() {
 		return
 	}
@@ -182,7 +182,7 @@ func (dv *DateView) SetTime(tim time.Time) *DateView {
 	return dv
 }
 
-func (dv *DateView) ConfigWidget(sc *gi.Scene) {
+func (dv *DateView) ConfigWidget() {
 	if dv.HasChildren() {
 		return
 	}
@@ -334,7 +334,7 @@ func (vv *TimeValue) UpdateWidget() {
 	fr.ChildByName("time").(*gi.TextField).SetText(tm.Format(gi.Prefs.TimeFormat()))
 }
 
-func (vv *TimeValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *TimeValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -383,7 +383,7 @@ func (vv *TimeValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 		// new date and old time
 		*tv = time.Date(d.Year(), d.Month(), d.Day(), tv.Hour(), tv.Minute(), tv.Second(), tv.Nanosecond(), tv.Location())
 	})
-	dt.Config(sc)
+	dt.Config()
 
 	tm := gi.NewTextField(ly, "time").SetTooltip("The time").
 		SetLeadingIcon(icons.Schedule, func(e events.Event) {
@@ -415,7 +415,7 @@ func (vv *TimeValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 		// old date and new time
 		*tv = time.Date(tv.Year(), tv.Month(), tv.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tv.Location())
 	})
-	dt.Config(sc)
+	dt.Config()
 
 	vv.UpdateWidget()
 }
@@ -482,7 +482,7 @@ func (vv *DurationValue) UpdateWidget() {
 	ly.ChildByName("unit").(*gi.Chooser).SetCurVal(un)
 }
 
-func (vv *DurationValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *DurationValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -505,7 +505,7 @@ func (vv *DurationValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	sp.OnChange(func(e events.Event) {
 		vv.SetValue(sp.Value * float32(durationUnitsMap[ch.CurLabel]))
 	})
-	sp.Config(sc)
+	sp.Config()
 
 	units := []any{}
 	for _, u := range durationUnits {

--- a/giv/treesync.go
+++ b/giv/treesync.go
@@ -93,7 +93,7 @@ func (tv *TreeView) SyncToSrc(tvIdx *int, init bool, depth int) {
 	}
 	mods, updt := tv.ConfigChildren(tnl) // false = don't use unique names -- needs to!
 	if mods {
-		tv.SetNeedsLayout()
+		tv.SetNeedsLayout(true)
 		// fmt.Printf("got mod on %v\n", tv.Path())
 	}
 	idx := 0

--- a/giv/treeview.go
+++ b/giv/treeview.go
@@ -223,8 +223,8 @@ func (tv *TreeView) TreeViewStyles() {
 					return
 				}
 				tv.SetState(true, states.Hovered)
-				tv.ApplyStyle(tv.Sc)
-				tv.SetNeedsRender()
+				tv.ApplyStyle()
+				tv.SetNeedsRender(true)
 				e.SetHandled()
 			})
 			w.On(events.MouseLeave, func(e events.Event) {
@@ -232,8 +232,8 @@ func (tv *TreeView) TreeViewStyles() {
 					return
 				}
 				tv.SetState(false, states.Hovered)
-				tv.ApplyStyle(tv.Sc)
-				tv.SetNeedsRender()
+				tv.ApplyStyle()
+				tv.SetNeedsRender(true)
 				e.SetHandled()
 			})
 			w.On(events.MouseDown, func(e events.Event) {
@@ -241,8 +241,8 @@ func (tv *TreeView) TreeViewStyles() {
 					return
 				}
 				tv.SetState(true, states.Active)
-				tv.ApplyStyle(tv.Sc)
-				tv.SetNeedsRender()
+				tv.ApplyStyle()
+				tv.SetNeedsRender(true)
 				e.SetHandled()
 			})
 			w.On(events.MouseUp, func(e events.Event) {
@@ -250,8 +250,8 @@ func (tv *TreeView) TreeViewStyles() {
 					return
 				}
 				tv.SetState(false, states.Active)
-				tv.ApplyStyle(tv.Sc)
-				tv.SetNeedsRender()
+				tv.ApplyStyle()
+				tv.SetNeedsRender(true)
 				e.SetHandled()
 			})
 			w.OnClick(func(e events.Event) {
@@ -436,7 +436,7 @@ func (tv *TreeView) LabelPart() (*gi.Label, bool) {
 	return nil, false
 }
 
-func (tv *TreeView) ConfigParts(sc *gi.Scene) {
+func (tv *TreeView) ConfigParts() {
 	parts := tv.NewParts()
 	config := ki.Config{}
 	config.Add(gi.SwitchType, "branch")
@@ -448,7 +448,7 @@ func (tv *TreeView) ConfigParts(sc *gi.Scene) {
 	if tv.HasChildren() {
 		if wb, ok := tv.BranchPart(); ok {
 			tv.SetBranchState()
-			wb.Config(sc)
+			wb.Config()
 		}
 	}
 	if tv.Icon.IsValid() {
@@ -465,26 +465,26 @@ func (tv *TreeView) ConfigParts(sc *gi.Scene) {
 	}
 }
 
-func (tv *TreeView) ConfigWidget(sc *gi.Scene) {
-	tv.ConfigParts(sc)
+func (tv *TreeView) ConfigWidget() {
+	tv.ConfigParts()
 }
 
-func (tv *TreeView) StyleTreeView(sc *gi.Scene) {
+func (tv *TreeView) StyleTreeView() {
 	if !tv.HasChildren() {
 		tv.SetClosed(true)
 	}
 	tv.Indent.ToDots(&tv.Styles.UnContext)
 	// tv.Parts.Styles.InheritFields(&tv.Styles)
-	tv.ApplyStyleWidget(sc)
+	tv.ApplyStyleWidget()
 	// tv.Styles.StateLayer = 0 // turn off!
 	// note: this is essential for reasonable styling behavior
 }
 
-func (tv *TreeView) ApplyStyle(sc *gi.Scene) {
+func (tv *TreeView) ApplyStyle() {
 	tv.StyMu.Lock() // todo: needed??  maybe not.
 	defer tv.StyMu.Unlock()
 
-	tv.StyleTreeView(sc)
+	tv.StyleTreeView()
 }
 
 func (tv *TreeView) UpdateBranchIcons() {
@@ -501,19 +501,19 @@ func (tv *TreeView) SetBranchState() {
 	case tv.IsClosed():
 		br.SetState(false, states.Disabled)
 		br.SetState(false, states.Checked)
-		br.SetNeedsRender()
+		br.SetNeedsRender(true)
 	default:
 		br.SetState(false, states.Disabled)
 		br.SetState(true, states.Checked)
-		br.SetNeedsRender()
+		br.SetNeedsRender(true)
 	}
 }
 
 // TreeView is tricky for alloc because it is both a layout
 // of its children but has to maintain its own bbox for its own widget.
 
-func (tv *TreeView) SizeUp(sc *gi.Scene) {
-	tv.WidgetBase.SizeUp(sc)
+func (tv *TreeView) SizeUp() {
+	tv.WidgetBase.SizeUp()
 	tv.WidgetSize = tv.Geom.Size.Actual.Total
 	h := tv.WidgetSize.Y
 	w := tv.WidgetSize.X
@@ -521,7 +521,7 @@ func (tv *TreeView) SizeUp(sc *gi.Scene) {
 	if !tv.IsClosed() {
 		// we layout children under us
 		tv.WidgetKidsIter(func(i int, kwi gi.Widget, kwb *gi.WidgetBase) bool {
-			kwi.SizeUp(sc)
+			kwi.SizeUp()
 			h += kwb.Geom.Size.Actual.Total.Y
 			w = max(w, tv.Indent.Dots+kwb.Geom.Size.Actual.Total.X)
 			// fmt.Println(kwb, w, h)
@@ -535,14 +535,14 @@ func (tv *TreeView) SizeUp(sc *gi.Scene) {
 	tv.WidgetSize.X = w  // stretch
 }
 
-func (tv *TreeView) SizeDown(sc *gi.Scene, iter int) bool {
+func (tv *TreeView) SizeDown(iter int) bool {
 	// note: key to not grab the whole allocation, as widget default does
-	redo := tv.SizeDownParts(sc, iter) // give our content to parts
-	re := tv.SizeDownChildren(sc, iter)
+	redo := tv.SizeDownParts(iter) // give our content to parts
+	re := tv.SizeDownChildren(iter)
 	return redo || re
 }
 
-func (tv *TreeView) Position(sc *gi.Scene) {
+func (tv *TreeView) Position() {
 	rn := tv.RootView
 	if rn == nil {
 		slog.Error("giv.TreeView: RootView is nil", "in node:", tv)
@@ -554,7 +554,7 @@ func (tv *TreeView) Position(sc *gi.Scene) {
 	tv.Geom.Size.Actual.Total.X = rn.Geom.Size.Actual.Total.X - (tv.Geom.Pos.Total.X - rn.Geom.Pos.Total.X)
 	tv.WidgetSize.X = tv.Geom.Size.Actual.Total.X
 
-	tv.WidgetBase.Position(sc)
+	tv.WidgetBase.Position()
 
 	if !tv.IsClosed() {
 		h := tv.WidgetSize.Y
@@ -562,24 +562,24 @@ func (tv *TreeView) Position(sc *gi.Scene) {
 			kwb.Geom.RelPos.Y = h
 			kwb.Geom.RelPos.X = tv.Indent.Dots
 			h += kwb.Geom.Size.Actual.Total.Y
-			kwi.Position(sc)
+			kwi.Position()
 			return ki.Continue
 		})
 	}
 }
 
-func (tv *TreeView) ScenePos(sc *gi.Scene) {
+func (tv *TreeView) ScenePos() {
 	sz := &tv.Geom.Size
 	if sz.Actual.Total == tv.WidgetSize {
 		sz.SetTotalFromContent(&sz.Actual) // restore after scrolling
 	}
-	tv.WidgetBase.ScenePos(sc)
-	tv.ScenePosChildren(sc)
+	tv.WidgetBase.ScenePos()
+	tv.ScenePosChildren()
 	tv.Geom.Size.Actual.Total = tv.WidgetSize // key: we revert to just ourselves
 }
 
-func (tv *TreeView) RenderNode(sc *gi.Scene) {
-	rs, pc, st := tv.RenderLock(sc)
+func (tv *TreeView) RenderNode() {
+	rs, pc, st := tv.RenderLock()
 	// must use workaround act values
 	st.StateLayer = tv.actStateLayer
 	if st.Is(states.Selected) {
@@ -596,23 +596,23 @@ func (tv *TreeView) RenderNode(sc *gi.Scene) {
 	}
 }
 
-func (tv *TreeView) Render(sc *gi.Scene) {
-	if tv.PushBounds(sc) {
-		tv.RenderNode(sc)
+func (tv *TreeView) Render() {
+	if tv.PushBounds() {
+		tv.RenderNode()
 		if tv.Parts != nil {
 			// we must copy from actual values in parent
 			tv.Parts.Styles.StateLayer = tv.actStateLayer
 			if tv.StateIs(states.Selected) {
 				tv.Parts.Styles.BackgroundColor.SetSolid(colors.Scheme.Select.Container)
 			}
-			tv.RenderParts(sc)
+			tv.RenderParts()
 		}
-		tv.PopBounds(sc)
+		tv.PopBounds()
 	}
 	// we always have to render our kids b/c
 	// we could be out of scope but they could be in!
 	if !tv.IsClosed() {
-		tv.RenderChildren(sc)
+		tv.RenderChildren()
 	}
 }
 
@@ -662,11 +662,11 @@ func (tv *TreeView) HasSelection() bool {
 func (tv *TreeView) Select() {
 	if !tv.StateIs(states.Selected) {
 		tv.SetSelected(true)
-		tv.ApplyStyle(tv.Sc)
+		tv.ApplyStyle()
 		sl := tv.SelectedViews()
 		sl = append(sl, tv)
 		tv.SetSelectedViews(sl)
-		tv.SetNeedsRender()
+		tv.SetNeedsRender(true)
 	}
 }
 
@@ -675,7 +675,7 @@ func (tv *TreeView) Select() {
 func (tv *TreeView) Unselect() {
 	if tv.StateIs(states.Selected) {
 		tv.SetSelected(false)
-		tv.ApplyStyle(tv.Sc)
+		tv.ApplyStyle()
 		sl := tv.SelectedViews()
 		sz := len(sl)
 		for i := 0; i < sz; i++ {
@@ -685,7 +685,7 @@ func (tv *TreeView) Unselect() {
 			}
 		}
 		tv.SetSelectedViews(sl)
-		tv.SetNeedsRender()
+		tv.SetNeedsRender(true)
 	}
 }
 
@@ -699,8 +699,8 @@ func (tv *TreeView) UnselectAll() {
 	tv.SetSelectedViews(nil) // clear in advance
 	for _, v := range sl {
 		v.SetSelected(false)
-		v.ApplyStyle(tv.Sc)
-		v.SetNeedsRender()
+		v.ApplyStyle()
+		v.SetNeedsRender(true)
 	}
 	tv.UpdateEndRender(updt)
 }
@@ -1095,7 +1095,7 @@ func (tv *TreeView) Close() {
 	}
 	updt := tv.UpdateStart()
 	if tv.HasChildren() {
-		tv.SetNeedsLayout()
+		tv.SetNeedsLayout(true)
 	}
 	tv.SetClosed(true)
 	tv.SetBranchState()
@@ -1118,7 +1118,7 @@ func (tv *TreeView) Open() {
 	}
 	updt := tv.UpdateStart()
 	if tv.HasChildren() {
-		tv.SetNeedsLayout()
+		tv.SetNeedsLayout(true)
 		tv.SetClosed(false)
 		tv.SetBranchState()
 		tv.This().(TreeViewer).OnOpen()
@@ -1858,89 +1858,4 @@ func (tv *TreeView) HandleTreeViewDrag() {
 			}
 		})
 	*/
-}
-
-var TreeViewProps = ki.Props{
-	"CtxtMenuActive": ki.PropSlice{
-		{"SrcAddChild", ki.Props{
-			"label": "Add Child",
-		}},
-		{"SrcInsertBefore", ki.Props{
-			"label":    "Insert Before",
-			"shortcut": keyfun.Insert,
-			"updtfunc": ActionUpdateFunc(func(tvi any, act *gi.Button) {
-				// tv := tvi.(ki.Ki).Embed(TreeViewType).(*TreeView)
-				// act.SetState(tv.IsRoot(""), states.Disabled)
-			}),
-		}},
-		{"SrcInsertAfter", ki.Props{
-			"label":    "Insert After",
-			"shortcut": keyfun.InsertAfter,
-			"updtfunc": ActionUpdateFunc(func(tvi any, act *gi.Button) {
-				// tv := tvi.(ki.Ki).Embed(TreeViewType).(*TreeView)
-				// act.SetState(tv.IsRoot(""), states.Disabled)
-			}),
-		}},
-		{"SrcDuplicate", ki.Props{
-			"label":    "Duplicate",
-			"shortcut": keyfun.Duplicate,
-			"updtfunc": ActionUpdateFunc(func(tvi any, act *gi.Button) {
-				// tv := tvi.(ki.Ki).Embed(TreeViewType).(*TreeView)
-				// act.SetState(tv.IsRoot(""), states.Disabled)
-			}),
-		}},
-		{"SrcDelete", ki.Props{
-			"label":    "Delete",
-			"shortcut": keyfun.Delete,
-			"updtfunc": ActionUpdateFunc(func(tvi any, act *gi.Button) {
-				// tv := tvi.(ki.Ki).Embed(TreeViewType).(*TreeView)
-				// act.SetState(tv.IsRoot(""), states.Disabled)
-			}),
-		}},
-		{"sep-edit", ki.BlankProp{}},
-		{"Copy", ki.Props{
-			"shortcut": keyfun.Copy,
-			"Args": ki.PropSlice{
-				{"reset", ki.Props{
-					"value": true,
-				}},
-			},
-		}},
-		{"Cut", ki.Props{
-			"shortcut": keyfun.Cut,
-			"updtfunc": ActionUpdateFunc(func(tvi any, act *gi.Button) {
-				// tv := tvi.(ki.Ki).Embed(TreeViewType).(*TreeView)
-				// act.SetState(tv.IsRoot(""), states.Disabled)
-			}),
-		}},
-		{"Paste", ki.Props{
-			"shortcut": keyfun.Paste,
-		}},
-		{"sep-win", ki.BlankProp{}},
-		{"SrcEdit", ki.Props{
-			"label": "Edit",
-		}},
-		{"SrcInspector", ki.Props{
-			"label": "Inspector",
-		}},
-		{"sep-open", ki.BlankProp{}},
-		{"OpenAll", ki.Props{}},
-		{"CloseAll", ki.Props{}},
-	},
-	"CtxtMenuReadOnly": ki.PropSlice{
-		{"Copy", ki.Props{
-			"shortcut": keyfun.Copy,
-			"Args": ki.PropSlice{
-				{"reset", ki.Props{
-					"value": true,
-				}},
-			},
-		}},
-		{"SrcEdit", ki.Props{
-			"label": "Edit",
-		}},
-		{"SrcInspector", ki.Props{
-			"label": "Inspector",
-		}},
-	},
 }

--- a/giv/value.go
+++ b/giv/value.go
@@ -36,7 +36,7 @@ import (
 func NewValue(par ki.Ki, val any, name ...string) Value {
 	v := NewSoloValue(val)
 	w := par.NewChild(v.WidgetType()).(gi.Widget)
-	v.ConfigWidget(w, w.AsWidget().Sc)
+	v.ConfigWidget(w)
 	return v
 }
 
@@ -160,7 +160,7 @@ type Value interface {
 	// when the user edits it (values are always set immediately when the
 	// widget is updated).  Note: use OnLast(events.Change) to ensure that
 	// any other change modifiers have had a chance to intervene first.
-	ConfigWidget(w gi.Widget, sc *gi.Scene)
+	ConfigWidget(w gi.Widget)
 
 	// HasDialog returns true if this value has an associated Dialog,
 	// e.g., for FileName, StructView, SliceView, etc.
@@ -803,7 +803,7 @@ func (vv *ValueBase) UpdateWidget() {
 	}
 }
 
-func (vv *ValueBase) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *ValueBase) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -834,7 +834,7 @@ func (vv *ValueBase) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 		tf.SetTypePassword()
 	}
 
-	tf.Config(sc)
+	tf.Config()
 	tf.OnChange(func(e events.Event) {
 		if vv.SetValue(tf.Text()) {
 			vv.UpdateWidget() // always update after setting value..

--- a/giv/values.go
+++ b/giv/values.go
@@ -394,7 +394,7 @@ func (vv *StructValue) UpdateWidget() {
 	}
 }
 
-func (vv *StructValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *StructValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -406,7 +406,7 @@ func (vv *StructValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	bt.SetType(gi.ButtonTonal)
 	bt.Icon = icons.Edit
 	bt.Tooltip = vv.Doc()
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		vv.OpenDialog(vv.Widget, nil)
 	})
@@ -451,7 +451,7 @@ func (vv *StructInlineValue) UpdateWidget() {
 	sv.SetStruct(cst)
 }
 
-func (vv *StructInlineValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *StructInlineValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -516,7 +516,7 @@ func (vv *SliceValue) GetTypeInfo() {
 	}
 }
 
-func (vv *SliceValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *SliceValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -528,7 +528,7 @@ func (vv *SliceValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	bt.SetType(gi.ButtonTonal)
 	bt.Icon = icons.Edit
 	bt.Tooltip = vv.Doc()
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		vv.OpenDialog(vv.Widget, nil)
 	})
@@ -599,7 +599,7 @@ func (vv *SliceInlineValue) UpdateWidget() {
 	}
 }
 
-func (vv *SliceInlineValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *SliceInlineValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -647,7 +647,7 @@ func (vv *MapValue) UpdateWidget() {
 	bt.SetTextUpdate(txt)
 }
 
-func (vv *MapValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *MapValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -658,7 +658,7 @@ func (vv *MapValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	bt.SetType(gi.ButtonTonal)
 	bt.Icon = icons.Edit
 	bt.Tooltip = vv.Doc()
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		vv.OpenDialog(vv.Widget, nil)
 	})
@@ -705,7 +705,7 @@ func (vv *MapInlineValue) UpdateWidget() {
 	}
 }
 
-func (vv *MapInlineValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *MapInlineValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -769,7 +769,7 @@ func (vv *KiPtrValue) UpdateWidget() {
 	bt.SetTextUpdate(path)
 }
 
-func (vv *KiPtrValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *KiPtrValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -794,7 +794,7 @@ func (vv *KiPtrValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 			}
 		})
 	}
-	bt.Config(sc)
+	bt.Config()
 	vv.UpdateWidget()
 }
 
@@ -835,7 +835,7 @@ func (vv *BoolValue) UpdateWidget() {
 	cb.SetState(bv, states.Checked)
 }
 
-func (vv *BoolValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *BoolValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -844,7 +844,7 @@ func (vv *BoolValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	cb := vv.Widget.(*gi.Switch)
 	cb.Tooltip = vv.Doc()
-	cb.Config(sc)
+	cb.Config()
 	cb.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(cb.StateIs(states.Checked))
 	})
@@ -878,7 +878,7 @@ func (vv *IntValue) UpdateWidget() {
 	}
 }
 
-func (vv *IntValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *IntValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -924,7 +924,7 @@ func (vv *IntValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	if fmttag, ok := vv.Tag("format"); ok {
 		sb.Format = fmttag
 	}
-	sb.Config(sc)
+	sb.Config()
 	sb.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(sb.Value)
 	})
@@ -958,7 +958,7 @@ func (vv *FloatValue) UpdateWidget() {
 	}
 }
 
-func (vv *FloatValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *FloatValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -999,7 +999,7 @@ func (vv *FloatValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	if fmttag, ok := vv.Tag("format"); ok {
 		sb.Format = fmttag
 	}
-	sb.Config(sc)
+	sb.Config()
 	sb.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(sb.Value)
 	})
@@ -1033,7 +1033,7 @@ func (vv *SliderValue) UpdateWidget() {
 	}
 }
 
-func (vv *SliderValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *SliderValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1067,7 +1067,7 @@ func (vv *SliderValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 			slog.Error("Float Step Value:", "error:", err)
 		}
 	}
-	sl.Config(sc)
+	sl.Config()
 	sl.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(sl.Value)
 	})
@@ -1118,7 +1118,7 @@ func (vv *EnumValue) UpdateWidget() {
 	// }
 }
 
-func (vv *EnumValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *EnumValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1130,7 +1130,7 @@ func (vv *EnumValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 
 	ev := vv.EnumValue()
 	ch.SetEnum(ev, false, 50)
-	ch.Config(sc)
+	ch.Config()
 	ch.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(ch.CurVal)
 	})
@@ -1178,7 +1178,7 @@ func (vv *BitFlagValue) UpdateWidget() {
 	sw.UpdateFromBitFlag(ev)
 }
 
-func (vv *BitFlagValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *BitFlagValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1193,7 +1193,7 @@ func (vv *BitFlagValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	sw.OnChange(func(e events.Event) {
 		sw.BitFlagValue(vv.EnumValue())
 	})
-	sw.Config(sc)
+	sw.Config()
 	vv.UpdateWidget()
 }
 
@@ -1223,7 +1223,7 @@ func (vv *TypeValue) UpdateWidget() {
 	}
 }
 
-func (vv *TypeValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *TypeValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1252,7 +1252,7 @@ func (vv *TypeValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 
 	tl := gti.AllEmbeddersOf(typEmbeds)
 	cb.SetTypes(tl, false, true, 50)
-	cb.Config(sc)
+	cb.Config()
 	cb.OnLast(events.Change, func(e events.Event) {
 		tval := cb.CurVal.(*gti.Type)
 		vv.SetValue(tval)
@@ -1285,7 +1285,7 @@ func (vv *ByteSliceValue) UpdateWidget() {
 	}
 }
 
-func (vv *ByteSliceValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *ByteSliceValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1298,7 +1298,7 @@ func (vv *ByteSliceValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 		s.Min.X.Ch(16)
 	})
 	vv.StdConfigWidget(w)
-	tf.Config(sc)
+	tf.Config()
 
 	tf.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(tf.Text())
@@ -1331,7 +1331,7 @@ func (vv *RuneSliceValue) UpdateWidget() {
 	}
 }
 
-func (vv *RuneSliceValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *RuneSliceValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1343,7 +1343,7 @@ func (vv *RuneSliceValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 		s.Min.X.Ch(16)
 	})
 	vv.StdConfigWidget(w)
-	tf.Config(sc)
+	tf.Config()
 
 	tf.OnLast(events.Change, func(e events.Event) {
 		vv.SetValue(tf.Text())
@@ -1379,7 +1379,7 @@ func (vv *NilValue) UpdateWidget() {
 	sb.SetTextUpdate("nil " + tstr)
 }
 
-func (vv *NilValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *NilValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1388,7 +1388,7 @@ func (vv *NilValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	sb := vv.Widget.(*gi.Label)
 	sb.Tooltip = vv.Doc()
-	sb.Config(sc)
+	sb.Config()
 	vv.UpdateWidget()
 }
 
@@ -1427,7 +1427,7 @@ func (vv *IconValue) UpdateWidget() {
 	}
 }
 
-func (vv *IconValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *IconValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1436,7 +1436,7 @@ func (vv *IconValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)
@@ -1454,7 +1454,7 @@ func (vv *IconValue) ConfigDialog(d *gi.Body) (bool, func()) {
 	cur := icons.Icon(laser.ToString(vv.Value.Interface()))
 	NewSliceView(d).SetStyleFunc(func(w gi.Widget, s *styles.Style, row int) {
 		w.(*gi.Button).SetText(sentencecase.Of(strcase.ToCamel(string(ics[row]))))
-	}).SetSlice(&ics).SetSelVal(cur).BindSelectDialog(d.Sc, &si)
+	}).SetSlice(&ics).SetSelVal(cur).BindSelectDialog(&si)
 	return true, func() {
 		if si >= 0 {
 			ic := icons.AllIcons[si]
@@ -1488,7 +1488,7 @@ func (vv *FontValue) UpdateWidget() {
 	bt.SetTextUpdate(txt)
 }
 
-func (vv *FontValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *FontValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1497,7 +1497,7 @@ func (vv *FontValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)
@@ -1528,7 +1528,7 @@ func (vv *FontValue) ConfigDialog(d *gi.Body) (bool, func()) {
 		s.Font.Weight = fi[row].Weight
 		s.Font.Style = fi[row].Style
 		s.Font.Size = FontChooserSize
-	}).SetSlice(&fi).SetSelVal(cur).BindSelectDialog(d.Sc, &si)
+	}).SetSlice(&fi).SetSelVal(cur).BindSelectDialog(&si)
 
 	return true, func() {
 		if si >= 0 {
@@ -1565,7 +1565,7 @@ func (vv *FileValue) UpdateWidget() {
 	bt.SetTextUpdate(txt)
 }
 
-func (vv *FileValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *FileValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1574,7 +1574,7 @@ func (vv *FileValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
 	vv.StdConfigWidget(w)
 	bt := vv.Widget.(*gi.Button)
 	bt.SetType(gi.ButtonTonal)
-	bt.Config(sc)
+	bt.Config()
 	bt.OnClick(func(e events.Event) {
 		if !vv.IsReadOnly() {
 			vv.OpenDialog(vv.Widget, nil)
@@ -1623,7 +1623,7 @@ func (vv *TextEditorValue) UpdateWidget() {
 	te.Buf.SetText([]byte(npv.String()))
 }
 
-func (vv *TextEditorValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *TextEditorValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return
@@ -1668,7 +1668,7 @@ func (vv *FuncValue) UpdateWidget() {
 	fbt.SetFunc(fun)
 }
 
-func (vv *FuncValue) ConfigWidget(w gi.Widget, sc *gi.Scene) {
+func (vv *FuncValue) ConfigWidget(w gi.Widget) {
 	if vv.Widget == w {
 		vv.UpdateWidget()
 		return

--- a/texteditor/editor.go
+++ b/texteditor/editor.go
@@ -304,7 +304,7 @@ func (ed *Editor) SetBuf(buf *Buf) *Editor {
 			ed.PosHistIdx = bhl - 1
 		}
 	}
-	ed.SetNeedsLayout()
+	ed.SetNeedsLayout(true)
 	return ed
 }
 
@@ -331,8 +331,8 @@ func (ed *Editor) LinesInserted(tbe *textbuf.Edit) {
 	ed.Offs = nof
 
 	ed.NLines += nsz
-	ed.SetNeedsRender()
-	ed.SetNeedsLayout()
+	ed.SetNeedsRender(true)
+	ed.SetNeedsLayout(true)
 }
 
 // LinesDeleted deletes lines of text and reformats remaining one
@@ -345,7 +345,7 @@ func (ed *Editor) LinesDeleted(tbe *textbuf.Edit) {
 	ed.Offs = append(ed.Offs[:stln], ed.Offs[edln:]...)
 
 	ed.NLines -= dsz
-	ed.SetNeedsLayout()
+	ed.SetNeedsLayout(true)
 }
 
 // BufSignal receives a signal from the Buf when underlying text
@@ -355,12 +355,12 @@ func (ed *Editor) BufSignal(sig BufSignals, tbe *textbuf.Edit) {
 	case BufDone:
 	case BufNew:
 		ed.ResetState()
-		ed.SetNeedsRender()
-		ed.SetNeedsLayout()
+		ed.SetNeedsRender(true)
+		ed.SetNeedsLayout(true)
 		ed.SetCursorShow(ed.CursorPos)
 	case BufMods:
-		ed.SetNeedsRender()
-		ed.SetNeedsLayout()
+		ed.SetNeedsRender(true)
+		ed.SetNeedsLayout(true)
 	case BufInsert:
 		if ed == nil || ed.This() == nil || !ed.This().(gi.Widget).IsVisible() {
 			return
@@ -390,8 +390,8 @@ func (ed *Editor) BufSignal(sig BufSignals, tbe *textbuf.Edit) {
 			ed.Update()
 		}
 	case BufMarkUpdt:
-		ed.SetNeedsRender()
-		ed.SetNeedsLayout() // comes from another goroutine
+		ed.SetNeedsRender(true)
+		ed.SetNeedsLayout(true) // comes from another goroutine
 	case BufClosed:
 		ed.SetBuf(nil)
 	}
@@ -440,13 +440,13 @@ func (ed *Editor) Redo() {
 ////////////////////////////////////////////////////
 //  Widget Interface
 
-func (ed *Editor) ConfigWidget(sc *gi.Scene) {
-	ed.SetNeedsRender()
-	ed.SetNeedsLayout()
+func (ed *Editor) ConfigWidget() {
+	ed.SetNeedsRender(true)
+	ed.SetNeedsLayout(true)
 }
 
 // StyleView sets the style of widget
-func (ed *Editor) StyleView(sc *gi.Scene) {
+func (ed *Editor) StyleView() {
 	ed.StyMu.Lock()
 	defer ed.StyMu.Unlock()
 
@@ -455,14 +455,14 @@ func (ed *Editor) StyleView(sc *gi.Scene) {
 			ed.Buf.SetHiStyle(histyle.StyleDefault)
 		}
 	}
-	ed.ApplyStyleWidget(sc)
+	ed.ApplyStyleWidget()
 	ed.CursorWidth.ToDots(&ed.Styles.UnContext)
 }
 
 // ApplyStyle calls StyleView and sets the style
-func (ed *Editor) ApplyStyle(sc *gi.Scene) {
+func (ed *Editor) ApplyStyle() {
 	// ed.SetFlag(true, gi.CanFocus) // always focusable
-	ed.StyleView(sc)
+	ed.StyleView()
 	ed.StyleSizes()
 }
 

--- a/texteditor/layout.go
+++ b/texteditor/layout.go
@@ -5,7 +5,6 @@
 package texteditor
 
 import (
-	"goki.dev/gi/v2/gi"
 	"goki.dev/girl/paint"
 	"goki.dev/mat32/v2"
 )
@@ -52,16 +51,16 @@ func (ed *Editor) UpdateFromAlloc() {
 
 // note: Layout reverts to basic Widget behavior for layout if no kids, like us..
 
-func (ed *Editor) SizeFinal(sc *gi.Scene) {
+func (ed *Editor) SizeFinal() {
 	sz := &ed.Geom.Size
-	ed.ManageOverflow(sc, 0, true)
-	ed.Layout.SizeFinal(sc)
+	ed.ManageOverflow(0, true)
+	ed.Layout.SizeFinal()
 	sbw := mat32.Ceil(ed.Styles.ScrollBarWidth.Dots)
 	sz.Actual.Content.X -= sbw // anticipate scroll
 	ed.UpdateFromAlloc()
 	ed.LayoutAllLines()
 	// fmt.Println(ed, "final pre manage, actual:", sz.Actual, "space:", sz.Space, "alloc:", sz.Alloc)
-	if ed.ManageOverflow(sc, 3, true) {
+	if ed.ManageOverflow(3, true) {
 		sz.Actual.Total = sz.Alloc.Total
 		if ed.HasScroll[mat32.X] {
 			sz.Actual.Total.Y -= sbw
@@ -76,15 +75,15 @@ func (ed *Editor) SizeFinal(sc *gi.Scene) {
 	}
 }
 
-func (ed *Editor) Position(sc *gi.Scene) {
-	ed.Layout.Position(sc)
-	ed.ConfigScrolls(sc)
+func (ed *Editor) Position() {
+	ed.Layout.Position()
+	ed.ConfigScrolls()
 }
 
-func (ed *Editor) ScenePos(sc *gi.Scene) {
-	ed.Layout.ScenePos(sc)
-	ed.GetScrollPosition(sc)
-	ed.PositionScrolls(sc)
+func (ed *Editor) ScenePos() {
+	ed.Layout.ScenePos()
+	ed.GetScrollPosition()
+	ed.PositionScrolls()
 }
 
 // LayoutAllLines generates TextRenders of lines
@@ -183,9 +182,9 @@ func (ed *Editor) LayoutLine(ln int) bool {
 	ed.Buf.MarkupMu.RUnlock()
 
 	if needLay {
-		ed.SetNeedsLayout()
+		ed.SetNeedsLayout(true)
 	} else {
-		ed.SetNeedsRender()
+		ed.SetNeedsRender(true)
 	}
 	return needLay
 }

--- a/texteditor/render.go
+++ b/texteditor/render.go
@@ -22,8 +22,8 @@ import (
 // Rendering Notes: all rendering is done in Render call.
 // Layout must be called whenever content changes across lines.
 
-func (ed *Editor) Render(sc *gi.Scene) {
-	if ed.PushBounds(sc) {
+func (ed *Editor) Render() {
+	if ed.PushBounds() {
 		ed.RenderAllLinesInBounds()
 		if ed.ScrollToCursorOnRender {
 			ed.ScrollToCursorOnRender = false
@@ -35,9 +35,9 @@ func (ed *Editor) Render(sc *gi.Scene) {
 		} else {
 			ed.StopCursor()
 		}
-		ed.RenderChildren(sc)
-		ed.PopBounds(sc)
-		ed.RenderScrolls(sc)
+		ed.RenderChildren()
+		ed.PopBounds()
+		ed.RenderScrolls()
 	} else {
 		ed.StopCursor()
 	}
@@ -563,7 +563,7 @@ func (ed *Editor) RenderLines(st, end int) bool {
 		// fmt.Printf("Render lines upload: tbbox: %v  twinbbox: %v\n", tBBox, tScBBox)
 		// sc.This().(gi.Scene).ScUploadRegion(tBBox, tScBBox)
 	}
-	ed.PopBounds(sc)
+	ed.PopBounds()
 	ed.UpdateEnd(updt)
 	return true
 }

--- a/texteditor/select.go
+++ b/texteditor/select.go
@@ -23,7 +23,7 @@ import (
 // triggers updating.
 func (ed *Editor) HighlightRegion(reg textbuf.Region) {
 	ed.Highlights = []textbuf.Region{reg}
-	ed.SetNeedsRender()
+	ed.SetNeedsRender(true)
 }
 
 // ClearHighlights clears the Highlights slice of all regions
@@ -32,7 +32,7 @@ func (ed *Editor) ClearHighlights() {
 		return
 	}
 	ed.Highlights = ed.Highlights[:0]
-	ed.SetNeedsRender()
+	ed.SetNeedsRender(true)
 }
 
 // ClearScopelights clears the Highlights slice of all regions


### PR DESCRIPTION
The `Scene` is always stored on the Widget already, so passing it makes no sense. It is a massive amount of pointless code that serves no purpose and results in no increased brevity, as the increase in code far outweighs the tiny amount of times it is actually used and you have to type `wb.Sc` instead of `sc`.