### PR TITLE
Replace deprecated `io/ioutil` functions

### DIFF
--- a/examples/texteditor/sample.go
+++ b/examples/texteditor/sample.go
@@ -8,7 +8,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -71,7 +71,7 @@ gimain.Run(app)
 		slog.Error(err.Error())
 		// return err
 	}
-	b, err := ioutil.ReadAll(fp)
+	b, err := io.ReadAll(fp)
 	txed.Txt = string(b)
 	fp.Close()
 

--- a/filetree/copypaste.go
+++ b/filetree/copypaste.go
@@ -6,7 +6,7 @@ package filetree
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -36,7 +36,7 @@ func (fn *Node) MimeData(md *mimedata.Mimes) {
 			slog.Error(err.Error())
 			return
 		}
-		b, err := ioutil.ReadAll(in)
+		b, err := io.ReadAll(in)
 		if err != nil {
 			slog.Error(err.Error())
 			return

--- a/giv/fileview.go
+++ b/giv/fileview.go
@@ -6,7 +6,6 @@ package giv
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -862,13 +861,11 @@ func (fv *FileView) FileComplete(data any, text string, posLn, posCh int) (md co
 func (fv *FileView) PathComplete(data any, path string, posLn, posCh int) (md complete.Matches) {
 	dir, seed := filepath.Split(path)
 	md.Seed = seed
-	d, err := os.Open(dir)
+
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return md
 	}
-	defer d.Close()
-
-	files, err := ioutil.ReadDir(dir)
 	var dirs = []string{}
 	for _, f := range files {
 		if f.IsDir() && !strings.HasPrefix(f.Name(), ".") {

--- a/texteditor/buf.go
+++ b/texteditor/buf.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"image/color"
-	"io/ioutil"
+	"io"
 	"log"
 	"log/slog"
 	"os"
@@ -554,7 +554,7 @@ func (tb *Buf) OpenFile(filename gi.FileName) error {
 	if err != nil {
 		return err
 	}
-	tb.Txt, err = ioutil.ReadAll(fp)
+	tb.Txt, err = io.ReadAll(fp)
 	fp.Close()
 	tb.SetFilename(string(filename))
 	tb.BytesToLines()

--- a/texteditor/textbuf/util.go
+++ b/texteditor/textbuf/util.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log/slog"
 	"os"
 	"strings"
@@ -49,7 +48,7 @@ func FileBytes(fpath string) ([]byte, error) {
 		slog.Error(err.Error())
 		return nil, err
 	}
-	txt, err := ioutil.ReadAll(fp)
+	txt, err := io.ReadAll(fp)
 	fp.Close()
 	if err != nil {
 		slog.Error(err.Error())


### PR DESCRIPTION
The `io/ioutil` package has been deprecated as of Go 1.16 [^1]. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

[^1]: https://golang.org/doc/go1.16#ioutil